### PR TITLE
Make sidebar items appear in front of support cards

### DIFF
--- a/Assets/Scripts/Controllers/CardController.cs
+++ b/Assets/Scripts/Controllers/CardController.cs
@@ -89,7 +89,7 @@ public class CardController : MonoBehaviour
         {
             _startingTargetPosition = _targetPostion.position;
 
-            _targetPostion.position = new Vector3(_targetPostion.position.x, _targetPostion.position.y - 5f, _targetPostion.position.z - 15);
+            _targetPostion.position = new Vector3(_targetPostion.position.x, _targetPostion.position.y - 5f, _targetPostion.position.z - 15f);
             _cardGlow.DOFade(1, .2f);
             transform.SetAsLastSibling(); //make sure this card is in front of the bottom cards.
         }
@@ -97,7 +97,7 @@ public class CardController : MonoBehaviour
         {
             _startingTargetPosition = _targetPostion.position;
 
-            _targetPostion.position = new Vector3(_targetPostion.position.x, _targetPostion.position.y + 5f, _targetPostion.position.z - 15);
+            _targetPostion.position = new Vector3(_targetPostion.position.x, _targetPostion.position.y + 5f, _targetPostion.position.z - 15f);
             _cardGlow.DOFade(1, .2f);
             transform.SetAsLastSibling(); //make sure this card is in front of the bottom cards.
         }

--- a/Assets/Scripts/Controllers/UIController.cs
+++ b/Assets/Scripts/Controllers/UIController.cs
@@ -36,15 +36,15 @@ public class UIController : MonoBehaviour
 
     [SerializeField, BoxGroup("Effects")] GameObject _attackTallyPS;         //the effect spawned by the card when tally the defense/attack amount
 
-
-
     Player _player1;
     Player _player2;
+    Transform _sidebar;
 
     public void InitialiseGame(Player player1, Player player2)
     {
         _player1 = player1;
         _player2 = player2;
+        _sidebar = _board.Find("Sidebar");
 
         UpdateUI();
 
@@ -68,7 +68,6 @@ public class UIController : MonoBehaviour
     // play the hand
     // Reverse role
     // next round
-
     public void DisplayHands()
     {
         // Cleanup old hand
@@ -81,8 +80,6 @@ public class UIController : MonoBehaviour
         // Display new hand
         StartCoroutine(DrawCards(_player1));
         StartCoroutine(DrawCards(_player2));
-
-
 
         // Update deck count
         _index1DeckCount.text = _player1.CurrentDeck.GetDeck().Count + "cards";
@@ -176,6 +173,9 @@ public class UIController : MonoBehaviour
                 _player1Cards[i].GetComponent<Image>().color = Color.black;
             }
         }
+
+        // Make pepemon card, stage & hp points appear in front of support cards
+        _sidebar.SetAsLastSibling();
     }
 
     /// <summary>


### PR DESCRIPTION
This PR makes the sidebar items (pepemon card, stage, hp) appear in front of support cards, as shown in the screenshots below (see also this [comment](https://github.com/pepem00n/unity-app/issues/15#issuecomment-1146685341)):

### Idle state
![afbeelding](https://user-images.githubusercontent.com/8208970/172025966-c57c278c-cf8e-4a19-9c58-1324fe532f64.png)

### Attack state
![afbeelding](https://user-images.githubusercontent.com/8208970/172025979-ff54dd68-7eff-46a3-baa3-0839d3c4f27e.png)

Resolves #15