### PR TITLE
Fix errors while editing decks

### DIFF
--- a/Assets/Scripts/Controllers/ScreenEditDeck.cs
+++ b/Assets/Scripts/Controllers/ScreenEditDeck.cs
@@ -24,7 +24,12 @@ public class ScreenEditDeck : MonoBehaviour
 
     public async void LoadAllCards(ulong deckId)
     {
-        SetUiLoadingState(true);
+        var deckDisplayComponent = _deckDisplay.GetComponent<DeckDisplay>();
+
+        _textLoading.SetActive(true);
+        deckDisplayComponent.ClearBattleCardsList();
+        deckDisplayComponent.ClearSupportCardsList();
+
         currentDeckId = deckId;
         var account = FindObjectOfType<MainMenuController>().web3.SelectedAccountAddress;
 
@@ -34,15 +39,9 @@ public class ScreenEditDeck : MonoBehaviour
         battleCard = await PepemonCardDeck.GetBattleCard(deckId);
         supportCards = await PepemonCardDeck.GetAllSupportCards(deckId);
 
-        _deckDisplay.GetComponent<DeckDisplay>().ReloadAllBattleCards(ownedCardIds, battleCard);
-        _deckDisplay.GetComponent<DeckDisplay>().ReloadAllSupportCards(ownedCardIds, supportCards);
-        SetUiLoadingState(false);
-    }
-
-    public void SetUiLoadingState(bool loadingInProgress)
-    {
-        _textLoading.SetActive(loadingInProgress);
-        _deckDisplay.SetActive(!loadingInProgress);
+        deckDisplayComponent.LoadAllBattleCards(ownedCardIds, battleCard);
+        deckDisplayComponent.LoadAllSupportCards(ownedCardIds, supportCards);
+        _textLoading.SetActive(false);
     }
 
     public async void HandleSaveButtonClick()
@@ -120,7 +119,7 @@ public class ScreenEditDeck : MonoBehaviour
                 // TODO: display error toast
             }
         }
-        if (newBattleCard == 0)
+        else if (newBattleCard != battleCard && newBattleCard == 0)
         {
             try
             {

--- a/Assets/Scripts/UI/DeckDisplay.cs
+++ b/Assets/Scripts/UI/DeckDisplay.cs
@@ -18,14 +18,24 @@ public class DeckDisplay : MonoBehaviour
         return _battleCardList.GetComponentsInChildren<CardPreview>()?.Where(it => it.isSelected).FirstOrDefault()?.cardId ?? 0;
     }
 
-    public void ReloadAllBattleCards(Dictionary<ulong, int> availableCardIds, ulong selectedBattleCard)
+    public void ClearBattleCardsList()
     {
-        // destroy before re-creating
         foreach (var battlecard in _battleCardList.GetComponentsInChildren<Button>())
         {
             Destroy(battlecard.gameObject);
         }
+    }
 
+    public void ClearSupportCardsList()
+    {
+        foreach (var battlecard in _supportCardList.GetComponentsInChildren<Button>())
+        {
+            Destroy(battlecard.gameObject);
+        }
+    }
+
+    public void LoadAllBattleCards(Dictionary<ulong, int> availableCardIds, ulong selectedBattleCard)
+    {
         if (selectedBattleCard != 0)
         {
             // selected card will appear first, makes it easier to de-select it
@@ -53,14 +63,8 @@ public class DeckDisplay : MonoBehaviour
         return result;
     }
 
-    public void ReloadAllSupportCards(Dictionary<ulong, int> availableCardIds, Dictionary<ulong, int> selectedSupportCards)
+    public void LoadAllSupportCards(Dictionary<ulong, int> availableCardIds, Dictionary<ulong, int> selectedSupportCards)
     {
-        // destroy before re-creating
-        foreach (var battlecard in _supportCardList.GetComponentsInChildren<Button>())
-        {
-            Destroy(battlecard.gameObject);
-        }
-
         // selected cards will appear first, makes it easier to de-select them
         foreach (var cardId in selectedSupportCards.Keys)
         {


### PR DESCRIPTION
Some errors ("Object reference not set to an instance of an object") may appear before loading a deck that has at least 1 battlecard or 1 support card set.

This PR fixes that.