### PR TITLE
Fix cards always appearing in the same order

### DIFF
--- a/Assets/Scripts/Controllers/GameController.cs
+++ b/Assets/Scripts/Controllers/GameController.cs
@@ -78,14 +78,12 @@ public class GameController : MonoBehaviour
             // add console.log calls in the PepemonBattle.sol contract to get this seed
             BattlePrepController.battleData.battleRngSeed = BigInteger.Parse(
                 "68188038832262297884772284640717549873770515354422947402145954532168121309549");
-            //BattlePrepController.battleData.player1BattleCard = 1;
             BattlePrepController.battleData.player1BattleCard = 4;
             BattlePrepController.battleData.player1SupportCards = new OrderedDictionary<ulong, int>()
             {
                 [12] = 1,
                 [28] = 2
             };
-            //BattlePrepController.battleData.player2BattleCard = 2;
             BattlePrepController.battleData.player2BattleCard = 8;
             BattlePrepController.battleData.player2SupportCards = new OrderedDictionary<ulong, int>()
             {
@@ -108,8 +106,6 @@ public class GameController : MonoBehaviour
             if (starterDeckID == botStarterDeck)
                 botStarterDeck = 10001;
             ulong botStarterPepemon = 7;
-            //if (pepemonStarterID == botStarterPepemon)
-            //    botStarterPepemon = 1;
 
             BattlePrepController.battleData.player2BattleCard = botStarterPepemon;
             BattlePrepController.battleData.player2SupportCards = GetAllSupportCards(botStarterDeck);
@@ -124,6 +120,7 @@ public class GameController : MonoBehaviour
             supportCards: CardsScriptableObjsData.GetAllCardsByIds(BattlePrepController.battleData.player2SupportCards));
 
         BattlePrepController.battleData.currentPlayerIsPlayer1 = true;
+
         //resetting them
         Web3Controller.instance.StarterDeckID = 0;
         Web3Controller.instance.StarterPepemonID = 0;
@@ -156,22 +153,16 @@ public class GameController : MonoBehaviour
 
     private void PrepareDecksBeforeBattle()
     {
-        ulong starterDeckID = 0;
-        if (Web3Controller.instance != null)
-            starterDeckID = Web3Controller.instance.StarterDeckID;
+        ulong starterDeckID = Web3Controller.instance?.StarterDeckID ?? 0;
 
+        // When player is going through the tutorial
         if (starterDeckID != 0)
         {
             PrepareSimulatedBattle(starterDeckID);
-            // when ran from Unity Editor. Set battleSeed and GameController cards to simulate a specific battle
-            Debug.LogWarning("Battle data not set from BattlePrepController");
-            battleSeed = 1;
+            battleSeed = new System.Random().NextBigInteger();
         }
         else
         {
-#if UNITY_EDITOR
-            PrepareSimulatedBattle(starterDeckID);
-#else
             // might be zero if ran from unity editor
             if (BattlePrepController.battleData.battleRngSeed != 0)
             {
@@ -191,7 +182,6 @@ public class GameController : MonoBehaviour
                 Debug.LogWarning("Battle data not set from BattlePrepController");
                 battleSeed = 1;
             }
-#endif
         }
         
     }
@@ -207,7 +197,7 @@ public class GameController : MonoBehaviour
     {
         _gameHasFinished = false;
         _currentAttacker = Attacker.PLAYER_ONE;
-        _roundNumber = 1;
+        _roundNumber = 0;
         _player1.Reset();
         _player2.Reset();
     }
@@ -215,7 +205,7 @@ public class GameController : MonoBehaviour
     // Each player shuffles their deck and draws cards equal to pepemon intelligence 
     void InitFirstRound()
     {
-        _roundNumber = 1;
+        _roundNumber = 0; // must start as 0
         _player1.Initialize();
         _player2.Initialize();
         _uiController.InitialiseGame(_player1, _player2);
@@ -719,7 +709,8 @@ public class GameController : MonoBehaviour
         return new(isTriggered, multiplier);
     }
 
-    public int GetRoundNumber() => _roundNumber;
+    // Used to display the current round. Note that current round must begin at 0 because its how it works in the blockchain
+    public int GetRoundNumber() => _roundNumber + 1;
 
 
     void BattleResut(Player winner)

--- a/Assets/Scripts/Controllers/MainMenuController.cs
+++ b/Assets/Scripts/Controllers/MainMenuController.cs
@@ -66,7 +66,7 @@ public class MainMenuController : MonoBehaviour
         }
     }
 
-    private void DeInitMainScene(bool toLoad)
+    private void DeInitMainScene(bool toLoadScreen)
     {
         // assume that when no account was selected and his scene loads, its because the game just launched
 
@@ -87,7 +87,9 @@ public class MainMenuController : MonoBehaviour
 
         */
 
-        if (toLoad)
+        // Show load screen in order to load cards into the PepemonFactoryCardCache.
+        // only necessary when launching the game from the battle scene
+        if (toLoadScreen)
         {
             _startGameButton.interactable = true;
             ShowScreen(defaultScreenId);

--- a/Assets/Scripts/Extensions/Random.cs
+++ b/Assets/Scripts/Extensions/Random.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System
+{
+    static public class RandomBigInt
+    {
+        /// <summary>
+        /// Returns a random BigInteger that is within a specified range.
+        /// The lower bound is inclusive, and the upper bound is exclusive.
+        /// </summary>
+        /// <see cref="https://stackoverflow.com/a/68593532"/>
+        public static BigInteger NextBigInteger(this Random random,
+            BigInteger minValue, BigInteger maxValue)
+        {
+            if (minValue > maxValue) throw new ArgumentException();
+            if (minValue == maxValue) return minValue;
+            BigInteger zeroBasedUpperBound = maxValue - 1 - minValue; // Inclusive
+
+            byte[] bytes = zeroBasedUpperBound.ToByteArray();
+
+            // Search for the most significant non-zero bit
+            byte lastByteMask = 0b11111111;
+            for (byte mask = 0b10000000; mask > 0; mask >>= 1, lastByteMask >>= 1)
+            {
+                if ((bytes[bytes.Length - 1] & mask) == mask) break; // We found it
+            }
+
+            while (true)
+            {
+                random.NextBytes(bytes);
+                bytes[bytes.Length - 1] &= lastByteMask;
+                var result = new BigInteger(bytes);
+                if (result <= zeroBasedUpperBound) return result + minValue;
+            }
+        }
+
+        /// <summary>
+        /// Returns a random BigInteger
+        /// </summary>
+        public static BigInteger NextBigInteger(this Random random)
+        {
+            // use max value for uint256 https://forum.openzeppelin.com/t/using-the-maximum-integer-in-solidity/3000
+            return NextBigInteger(random,BigInteger.Zero,
+                BigInteger.Parse("115792089237316195423570985008687907853269984665640564039457584007913129639935"));
+        }
+    }
+}

--- a/Assets/Scripts/Extensions/Random.cs.meta
+++ b/Assets/Scripts/Extensions/Random.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43f17f03ef85c3a4ea757381df137819
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Almost the entire battle logic was done to follow what exists in the [battle contract](https://github.com/pepemon-dao/battle-contracts/blob/master/contracts/PepemonBattle.sol), one of the first steps of a battle is to shuffle the deck, but since the first round was changed from 0 to 1 this was not happening