### PR TITLE
feat(onboarding): overhaul the first-battle flow

### DIFF
--- a/Assets/Prefabs/Card.prefab
+++ b/Assets/Prefabs/Card.prefab
@@ -710,7 +710,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &1455525532799518743
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SandboxNew.unity
+++ b/Assets/Scenes/SandboxNew.unity
@@ -6418,13 +6418,7 @@ MonoBehaviour:
   tutorialPanel: {fileID: 703023840}
   quitButton: {fileID: 1663285280}
   tutorialText: {fileID: 909649978}
-  tutorials:
-  - "Welcome to your first battle! Each battle lasts 5 rounds. The first player to
-    go down to 0 HP loses the battle. Let\u2019s go!"
-  - "Each player draws cards based on their Pepemon\u2019s INT. The Pepemon with
-    the highest SPD attacks first."
-  - "Attack power is based on your Pepemon\u2019s ATK, SP ATK and the support cards
-    drawn. Defense is based on DEF, SP DEF and support cards drawn. Let\u2019s go!"
+  continuePrompt: {fileID: 224339123}
 --- !u!1 &885881228
 GameObject:
   m_ObjectHideFlags: 0
@@ -15867,7 +15861,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: PRESS SPACE TO CONTINUE
+  m_text: TAP OR PRESS SPACE
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8bfa113c19e50f14981b514906a2f76f, type: 2}
   m_sharedMaterial: {fileID: 4582639141343757650, guid: 8bfa113c19e50f14981b514906a2f76f, type: 2}

--- a/Assets/Scenes/StartScreen.unity
+++ b/Assets/Scenes/StartScreen.unity
@@ -31856,8 +31856,8 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'TIP: Don''t worry about making the perfect choice now. You can always
-    adjust your decision later.'
+  m_text: 'Pick your starter. This is the one you''ll mint - you can collect the
+    rest later.'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8bfa113c19e50f14981b514906a2f76f, type: 2}
   m_sharedMaterial: {fileID: 4582639141343757650, guid: 8bfa113c19e50f14981b514906a2f76f, type: 2}

--- a/Assets/ScriptableObjects/Pepemons/Druky.asset
+++ b/Assets/ScriptableObjects/Pepemons/Druky.asset
@@ -24,6 +24,9 @@ MonoBehaviour:
   Weakness: 5
   Resistence: 8
   Rarity: 0
+  Tagline: Tank. Refuses to die.
+  Description: The most health and defense of any starter, and quick enough to swing
+    first. Druky grinds opponents down and refuses to die.
   HealthPoints: 30
   Speed: 14
   Intelligence: 4

--- a/Assets/ScriptableObjects/Pepemons/Fafny.asset
+++ b/Assets/ScriptableObjects/Pepemons/Fafny.asset
@@ -24,6 +24,9 @@ MonoBehaviour:
   Weakness: 0
   Resistence: 2
   Rarity: 0
+  Tagline: Glass cannon. Ends fights early.
+  Description: The hardest hitter of any starter and the thinnest health bar to match.
+    Fafny wins fast or not at all.
   HealthPoints: 20
   Speed: 5
   Intelligence: 4

--- a/Assets/Scripts/Battle.meta
+++ b/Assets/Scripts/Battle.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8ea66ce4c71148e08b34fcbf542ec9c3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Battle/TimeControl.cs
+++ b/Assets/Scripts/Battle/TimeControl.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Pepemon.Battle
+{
+    /// <summary>
+    /// Arbiter for Time.timeScale.
+    ///
+    /// Three separate systems freeze the game (tutorial beats, card preview) or change its
+    /// speed (battle fast-forward). When each wrote Time.timeScale directly the last writer
+    /// won: closing a card preview while a tutorial beat was up unfroze the battle behind it,
+    /// and leaving the battle scene mid-freeze left the menu scene stuck at timeScale 0.
+    ///
+    /// Freezes are reference-counted by holder key; speed only applies when nothing is
+    /// freezing. Statics survive scene loads, so <see cref="ResetAll"/> must be called when
+    /// entering a scene.
+    /// </summary>
+    public static class TimeControl
+    {
+        public const string HolderTutorial = "tutorial";
+        public const string HolderCardPreview = "cardPreview";
+
+        private static readonly HashSet<string> FreezeHolders = new HashSet<string>();
+        private static float _speed = 1f;
+
+        public static bool IsFrozen => FreezeHolders.Count > 0;
+        public static float Speed => _speed;
+
+        public static void Freeze(string holder)
+        {
+            if (string.IsNullOrEmpty(holder)) return;
+            FreezeHolders.Add(holder);
+            Apply();
+        }
+
+        public static void Unfreeze(string holder)
+        {
+            if (string.IsNullOrEmpty(holder)) return;
+            FreezeHolders.Remove(holder);
+            Apply();
+        }
+
+        /// <summary>Playback speed used whenever nothing is freezing the game.</summary>
+        public static void SetSpeed(float speed)
+        {
+            _speed = Mathf.Clamp(speed, 0.25f, 4f);
+            Apply();
+        }
+
+        /// <summary>
+        /// Clears every freeze and restores normal speed. Call on scene entry so a scene
+        /// change during a freeze can never leave the next scene stuck.
+        /// </summary>
+        public static void ResetAll()
+        {
+            FreezeHolders.Clear();
+            _speed = 1f;
+            Apply();
+        }
+
+        private static void Apply()
+        {
+            Time.timeScale = FreezeHolders.Count > 0 ? 0f : _speed;
+        }
+    }
+}

--- a/Assets/Scripts/Battle/TimeControl.cs.meta
+++ b/Assets/Scripts/Battle/TimeControl.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0ed129dc62f04828a342a36450503f8d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BattleRules.meta
+++ b/Assets/Scripts/BattleRules.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8cb9595a34fb4f968f3685bd76a84939
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BattleRules/Pepemon.BattleRules.asmdef
+++ b/Assets/Scripts/BattleRules/Pepemon.BattleRules.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "Pepemon.BattleRules",
+    "rootNamespace": "Pepemon.BattleRules",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": true
+}

--- a/Assets/Scripts/BattleRules/Pepemon.BattleRules.asmdef.meta
+++ b/Assets/Scripts/BattleRules/Pepemon.BattleRules.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a4e6b2340a754cd18e9472289125ab52
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BattleRules/StarterDeckAssembly.cs
+++ b/Assets/Scripts/BattleRules/StarterDeckAssembly.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+
+namespace Pepemon.BattleRules
+{
+    /// <summary>
+    /// Decides which support cards go into a freshly claimed starter deck.
+    ///
+    /// Pure and engine-free so it can be tested. The rules matter because the inputs are not
+    /// trustworthy: the faucet's granted token ids are not knowable ahead of time, the local
+    /// starter list may name cards the player does not own, and the contract enforces a cap
+    /// that would revert the whole assembly transaction if exceeded.
+    /// </summary>
+    public static class StarterDeckAssembly
+    {
+        /// <summary>
+        /// Maps the desired starter list to per-card amounts, clamped by ownership and by the
+        /// per-deck cap.
+        ///
+        /// Repeats in <paramref name="desiredIds"/> are counted, so a starter list naming the
+        /// same card three times asks for three copies - but never more than the player owns.
+        /// </summary>
+        /// <param name="desiredIds">Starter list, may contain duplicates.</param>
+        /// <param name="owned">Card id to owned quantity.</param>
+        /// <param name="maxSupportCards">Contract cap on total support cards per deck.</param>
+        /// <returns>Card id to amount to add. Empty when nothing can be added.</returns>
+        public static Dictionary<ulong, int> SelectSupportCards(
+            IReadOnlyList<ulong> desiredIds,
+            IReadOnlyDictionary<ulong, int> owned,
+            int maxSupportCards)
+        {
+            var selected = new Dictionary<ulong, int>();
+
+            if (desiredIds == null || owned == null || maxSupportCards <= 0) return selected;
+
+            // Preserve the starter list's order so a truncated deck keeps its intended core
+            // rather than an arbitrary hash ordering.
+            var wanted = new List<ulong>();
+            var counts = new Dictionary<ulong, int>();
+
+            foreach (var id in desiredIds)
+            {
+                if (counts.ContainsKey(id))
+                {
+                    counts[id]++;
+                }
+                else
+                {
+                    counts[id] = 1;
+                    wanted.Add(id);
+                }
+            }
+
+            var budget = maxSupportCards;
+
+            foreach (var id in wanted)
+            {
+                if (budget <= 0) break;
+
+                if (!owned.TryGetValue(id, out var ownedAmount) || ownedAmount <= 0) continue;
+
+                var amount = counts[id];
+                if (amount > ownedAmount) amount = ownedAmount;
+                if (amount > budget) amount = budget;
+                if (amount <= 0) continue;
+
+                selected[id] = amount;
+                budget -= amount;
+            }
+
+            return selected;
+        }
+
+        /// <summary>Total cards a selection will add. Never exceeds the cap passed in.</summary>
+        public static int TotalCards(IReadOnlyDictionary<ulong, int> selection)
+        {
+            var total = 0;
+            if (selection == null) return total;
+
+            foreach (var kvp in selection) total += kvp.Value;
+            return total;
+        }
+    }
+}

--- a/Assets/Scripts/BattleRules/StarterDeckAssembly.cs.meta
+++ b/Assets/Scripts/BattleRules/StarterDeckAssembly.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ab385b0d6454fd3af57aefe65087039
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BattleRules/TutorialWinGuarantee.cs
+++ b/Assets/Scripts/BattleRules/TutorialWinGuarantee.cs
@@ -1,0 +1,48 @@
+namespace Pepemon.BattleRules
+{
+    /// <summary>
+    /// Pure damage rules, isolated from MonoBehaviour so they can actually be tested.
+    ///
+    /// These mirror PepemonBattle.sol. The first-battle guarantee lives here rather than
+    /// inline in the battle coroutine because it is the single promise the onboarding makes:
+    /// the player must not lose their first fight.
+    /// </summary>
+    public static class TutorialWinGuarantee
+    {
+        /// <summary>
+        /// Damage for one attack. At least 1 always lands, which is what makes any battle
+        /// terminate: the defender loses HP on every exchange regardless of how well it
+        /// defends. Matches the contract rule.
+        /// </summary>
+        public static int ResolveDamage(int totalAttackPower, int totalDefensePower)
+        {
+            return totalAttackPower > totalDefensePower
+                ? totalAttackPower - totalDefensePower
+                : 1;
+        }
+
+        /// <summary>
+        /// Caps incoming damage so a protected player is left on 1 HP instead of dying.
+        ///
+        /// Returns the damage that should actually be applied. When protection is off, or the
+        /// blow is not lethal, the damage passes through untouched.
+        /// </summary>
+        public static int ClampLethalDamage(int currentHp, int incomingDamage, bool guaranteeSurvival)
+        {
+            if (!guaranteeSurvival) return incomingDamage;
+            if (currentHp <= 0) return incomingDamage;
+            if (currentHp - incomingDamage > 0) return incomingDamage;
+
+            var survivable = currentHp - 1;
+            return survivable > 0 ? survivable : 0;
+        }
+
+        /// <summary>
+        /// True when this blow would end the battle for the defender.
+        /// </summary>
+        public static bool IsLethal(int currentHp, int incomingDamage)
+        {
+            return currentHp - incomingDamage <= 0;
+        }
+    }
+}

--- a/Assets/Scripts/BattleRules/TutorialWinGuarantee.cs.meta
+++ b/Assets/Scripts/BattleRules/TutorialWinGuarantee.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f4ce48080b1d42058a6dfb227c84fe07
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Contracts/PepemonCardDeck.cs
+++ b/Assets/Scripts/Contracts/PepemonCardDeck.cs
@@ -89,6 +89,27 @@ public class PepemonCardDeck
     }
 
 
+    /// <summary>Number of decks owned by <paramref name="address"/>.</summary>
+    public static async Task<ulong> GetDeckCount(string address)
+    {
+        return await contract.Read<ulong>("getDeckCount", address);
+    }
+
+    /// <summary>Deck id at <paramref name="index"/> in the player's deck list.</summary>
+    public static async Task<ulong> GetPlayerDeckAt(string address, ulong index)
+    {
+        return await contract.Read<ulong>("playerToDecks", address, index);
+    }
+
+    /// <summary>
+    /// Contract-enforced cap on support cards per deck. Read rather than hardcoded so the
+    /// starter deck assembly cannot exceed it if the contract changes.
+    /// </summary>
+    public static async Task<int> GetMaxSupportCards()
+    {
+        return (int)await contract.Read<ulong>("MAX_SUPPORT_CARDS");
+    }
+
     public static async Task<List<ulong>> GetPlayerDecks(string address)
     {
         var deckCount = await contract.Read<ulong>("getDeckCount", address);

--- a/Assets/Scripts/Controllers/BattlePrepController.cs
+++ b/Assets/Scripts/Controllers/BattlePrepController.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 using Nethereum.Hex.HexTypes;
 using Nethereum.RPC.Eth.DTOs;
 using Pepemon.Battle;
+using Pepemon.Onboarding;
+using Pepemon.Telemetry;
 using Sirenix.OdinInspector;
 using Thirdweb;
 using UnityEngine;
@@ -49,12 +51,40 @@ public class BattlePrepController : MonoBehaviour
         if (isStarterDeck)
         {
             Web3Controller.instance.StarterDeckID = deckId;
+
+            // Also persisted: the post-battle screen clears StarterDeckID before loading the
+            // menu scene, so the claim that runs there would otherwise not know what to build.
+            OnboardingState.PendingStarterDeckId = (int)deckId;
         }
     }
-    
+
     public void OnPepemonSelected(int pepemonID)
     {
         Web3Controller.instance.StarterPepemonID = pepemonID;
+        OnboardingState.PendingStarterPepemonId = pepemonID;
+
+        Funnel.Track(Funnel.PepemonSelected, "pepemon_id", pepemonID);
+    }
+
+    /// <summary>
+    /// Card ids making up a starter deck, for assembling the claimed starter pack on-chain.
+    /// Mirrors the selection in <see cref="GetAllSupportCards"/>: anything that is not the
+    /// first starter deck falls back to the second.
+    /// </summary>
+    public List<ulong> GetStarterSupportCardIds(ulong deckId)
+    {
+        var source = deckId == 10001 ? starterDeck1 : starterDeck2;
+        var ids = new List<ulong>();
+
+        if (source == null) return ids;
+
+        foreach (var card in source)
+        {
+            if (card == null) continue;
+            ids.Add((ulong)card.ID);
+        }
+
+        return ids;
     }
 
     private async void OnSearchForOpponentButtonClick()

--- a/Assets/Scripts/Controllers/BotTextTutorial.cs
+++ b/Assets/Scripts/Controllers/BotTextTutorial.cs
@@ -1,70 +1,228 @@
-using NBitcoin;
-using Org.BouncyCastle.Utilities.IO.Pem;
-using System.Collections;
 using System.Collections.Generic;
+using Pepemon.Battle;
+using Pepemon.Onboarding;
+using Pepemon.Telemetry;
 using TMPro;
 using UnityEngine;
 
+/// <summary>
+/// Drives the first-battle tutorial beats.
+///
+/// Two behaviours changed here that matter:
+///
+/// 1. Advancing used to require the spacebar. On touch there is no spacebar and the panel
+///    froze the game, so mobile players were permanently stuck; the same happened on desktop
+///    WebGL whenever the canvas lost keyboard focus. Any of key / mouse / touch now advances.
+///
+/// 2. Short beats are toasts that never freeze the battle. Only the intro and victory beats
+///    are modal. Previously every beat froze the game and all of them fired inside round 1.
+///
+/// The copy itself lives in <see cref="TutorialScript"/> rather than in scene YAML.
+/// </summary>
 public class BotTextTutorial : MonoBehaviour
 {
     [SerializeField] private GameObject tutorialPanel;
     [SerializeField] private GameObject quitButton;
     [SerializeField] private TMP_Text tutorialText;
-    [SerializeField] private List<string> tutorials = new List<string>();
 
-    private bool isInTutorial = false;
+    /// <summary>Optional "tap to continue" hint. Hidden for toasts, which dismiss themselves.</summary>
+    [SerializeField] private GameObject continuePrompt;
 
-    public bool IsInTutorial { get { return isInTutorial; } }
+    /// <summary>Ignore input for a moment after a beat appears, so the click that dismissed
+    /// the previous beat cannot fall through and dismiss this one too.</summary>
+    private const float InputLockSeconds = 0.35f;
 
-    private int currentTutorialStateIndex = 0;
-    private const string TUTORIAL_STATE_KEY = "TUTORIAL_STATE_INDEX";
+    private bool isBeatVisible;
+    private bool isModal;
+    private int currentBeatId;
+
+    /// <summary>Beats shown this session, so a beat cannot repeat before it is persisted.</summary>
+    private readonly HashSet<int> shownThisSession = new HashSet<int>();
+
+    private float inputLockedUntilUnscaled;
+    private float toastHideAtUnscaled;
+    private float beatShownAtUnscaled;
 
     public static BotTextTutorial Instance;
 
-    public bool wasInTutorial { get; private set; } = false;
+    /// <summary>
+    /// True only while a modal beat is blocking the battle.
+    ///
+    /// Deliberately excludes toasts: callers use this to suppress gameplay VFX and input,
+    /// and a toast is ordinary gameplay.
+    /// </summary>
+    public bool IsInTutorial => isBeatVisible && isModal;
 
-    private void Start()
+    /// <summary>True while any beat - modal or toast - is on screen.</summary>
+    public bool IsBeatVisible => isBeatVisible;
+
+    /// <summary>True if the player saw any tutorial beat during this session.</summary>
+    public bool wasInTutorial { get; private set; }
+
+    private void Awake()
     {
+        // Assigned in Awake, not Start: GameController and PostBattleScreenController both
+        // dereference Instance and their Start order is not guaranteed.
         Instance = this;
-        currentTutorialStateIndex = PlayerPrefs.GetInt(TUTORIAL_STATE_KEY, 0);
+    }
+
+    private void OnDestroy()
+    {
+        if (Instance == this) Instance = null;
+
+        // Leaving the scene mid-beat must not leave the next scene frozen.
+        TimeControl.Unfreeze(TimeControl.HolderTutorial);
     }
 
     private void Update()
     {
-        if (isInTutorial)
+        if (!isBeatVisible) return;
+
+        if (isModal)
         {
-            if (Input.GetKeyDown(KeyCode.Space))
+            if (TryReadAdvanceInput(out var method)) Dismiss(method);
+            return;
+        }
+
+        // Toasts are dismissible early but expire on their own.
+        if (TryReadAdvanceInput(out var toastMethod))
+        {
+            Dismiss(toastMethod);
+            return;
+        }
+
+        if (Time.unscaledTime >= toastHideAtUnscaled) Dismiss("auto");
+    }
+
+    /// <summary>
+    /// Any of keyboard, mouse or touch advances a beat.
+    /// Uses unscaled time throughout - Time.time does not advance while a modal beat holds
+    /// the game at timeScale 0.
+    /// </summary>
+    private bool TryReadAdvanceInput(out string method)
+    {
+        method = null;
+
+        if (Time.unscaledTime < inputLockedUntilUnscaled) return false;
+
+        if (Input.GetKeyDown(KeyCode.Space) ||
+            Input.GetKeyDown(KeyCode.Return) ||
+            Input.GetKeyDown(KeyCode.KeypadEnter) ||
+            Input.GetKeyDown(KeyCode.Escape))
+        {
+            method = "key";
+            return true;
+        }
+
+        for (int i = 0; i < Input.touchCount; i++)
+        {
+            if (Input.GetTouch(i).phase == TouchPhase.Began)
             {
-                PlayerPrefs.SetInt(TUTORIAL_STATE_KEY, currentTutorialStateIndex);
-                Hide();
+                method = "touch";
+                return true;
             }
         }
-    }
 
-    private void Hide()
-    {
-        Time.timeScale = 1f;
-        isInTutorial = false;
-        tutorialPanel.SetActive(false);
-        quitButton.SetActive(true);
-    }
-
-    private void Show()
-    {
-        Time.timeScale = 0f;
-        isInTutorial = true;
-        wasInTutorial = true;
-        tutorialText.text = tutorials[currentTutorialStateIndex - 1].ToString();
-        tutorialPanel.SetActive(true);
-        quitButton.SetActive(false);
-    }
-
-    public void TriggerTutorialEvent(int eventId)
-    {
-        if (eventId > currentTutorialStateIndex)
+        if (Input.GetMouseButtonDown(0))
         {
-            currentTutorialStateIndex = eventId;
-            Show();
+            method = "mouse";
+            return true;
         }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Hides any visible beat immediately and releases the freeze.
+    ///
+    /// Called before the post-battle screen appears: that screen animates itself in and polls
+    /// its Animator, which cannot advance while a modal beat holds timeScale at 0.
+    /// </summary>
+    public void ForceDismiss()
+    {
+        if (!isBeatVisible) return;
+        Dismiss("forced");
+    }
+
+    /// <summary>Hook for a UI Button, so the prompt works even if raw input is swallowed.</summary>
+    public void Advance()
+    {
+        if (!isBeatVisible) return;
+        if (Time.unscaledTime < inputLockedUntilUnscaled) return;
+        Dismiss("button");
+    }
+
+    /// <summary>
+    /// Shows beat <paramref name="beatId"/> if the player has not already seen it.
+    /// Ids are defined in <see cref="TutorialScript"/>.
+    /// </summary>
+    public void TriggerTutorialEvent(int beatId)
+    {
+        if (shownThisSession.Contains(beatId)) return;
+        if (OnboardingState.HasSeenBeat(beatId)) return;
+        if (!TutorialScript.TryGetBeat(beatId, out var beat) || beat == null) return;
+
+        // A newer beat supersedes whatever is on screen rather than being dropped.
+        if (isBeatVisible) Dismiss("superseded");
+
+        shownThisSession.Add(beatId);
+        currentBeatId = beatId;
+        Show(beat);
+    }
+
+    private void Show(TutorialBeat beat)
+    {
+        isBeatVisible = true;
+        isModal = beat.Mode == TutorialBeatMode.Modal;
+        wasInTutorial = true;
+
+        beatShownAtUnscaled = Time.unscaledTime;
+        inputLockedUntilUnscaled = Time.unscaledTime + InputLockSeconds;
+        toastHideAtUnscaled = isModal
+            ? float.MaxValue
+            : Time.unscaledTime + Mathf.Max(1f, beat.ToastSeconds);
+
+        if (tutorialText != null) tutorialText.text = beat.Text;
+        if (tutorialPanel != null) tutorialPanel.SetActive(true);
+        if (continuePrompt != null) continuePrompt.SetActive(isModal);
+
+        // The quit button stays available at all times - the player must never be trapped.
+        if (quitButton != null) quitButton.SetActive(true);
+
+        if (isModal) TimeControl.Freeze(TimeControl.HolderTutorial);
+
+        Funnel.Track(
+            Funnel.TutorialBeatShown,
+            "beat", beat.Id,
+            "mode", isModal ? "modal" : "toast");
+    }
+
+    private void Dismiss(string inputMethod)
+    {
+        if (!isBeatVisible) return;
+
+        var msShown = Mathf.RoundToInt((Time.unscaledTime - beatShownAtUnscaled) * 1000f);
+
+        isBeatVisible = false;
+        isModal = false;
+        toastHideAtUnscaled = float.MaxValue;
+
+        TimeControl.Unfreeze(TimeControl.HolderTutorial);
+
+        if (tutorialPanel != null) tutorialPanel.SetActive(false);
+        if (quitButton != null) quitButton.SetActive(true);
+
+        // Persist only once the beat has actually been consumed, so an interrupted beat
+        // is shown again next time.
+        OnboardingState.MarkBeatSeen(currentBeatId);
+
+        Funnel.Track(
+            Funnel.TutorialBeatDismissed,
+            new Dictionary<string, object>
+            {
+                ["beat"] = currentBeatId,
+                ["ms_shown"] = msShown,
+                ["input_method"] = inputMethod
+            });
     }
 }

--- a/Assets/Scripts/Controllers/CardController.cs
+++ b/Assets/Scripts/Controllers/CardController.cs
@@ -45,8 +45,15 @@ public class CardController : MonoBehaviour
     public void PopulateCard(Card card)
     {
         HostedCard = card;
-        //_cardDisplayName.text = HostedCard.DisplayName;
-        //_cardDescription.text = HostedCard.CardDescription;
+
+        // Card identity was previously invisible in battle: these assignments were commented
+        // out and both objects disabled in Card.prefab, so the tutorial explained support
+        // cards the player had no way to read.
+        //
+        // Only the name is shown on the card itself - a full effect description is not legible
+        // at card scale in the WebGL build. The description is surfaced in CardPreviewController.
+        if (_cardDisplayName != null) _cardDisplayName.text = card.DisplayName;
+        if (_cardDescription != null) _cardDescription.text = card.CardDescription;
 
         /*
         switch (card.Type)
@@ -113,7 +120,7 @@ public class CardController : MonoBehaviour
 
         _targetScale = _startingScale * 1.1f;
 
-        SFXManager.Instance.SlideSFX();
+        if (SFXManager.Instance != null) SFXManager.Instance.SlideSFX();
     }
 
     /// <summary>

--- a/Assets/Scripts/Controllers/CardPreviewController.cs
+++ b/Assets/Scripts/Controllers/CardPreviewController.cs
@@ -16,6 +16,11 @@ public class CardPreviewController : MonoBehaviour
     [Header("Game Card")]
     [SerializeField] private Image _cardImg;
 
+    // Optional. Until these are wired in the scene the preview shows artwork only, which is
+    // why players could not read what any support card actually did.
+    [SerializeField] private TextMeshProUGUI _cardNameText;
+    [SerializeField] private TextMeshProUGUI _cardDescriptionText;
+
     [Header("Pepemon Card")]
     [BoxGroup("Images"), SerializeField] private Image _backDropImage;
     [BoxGroup("Images"), SerializeField] private Image _cardContent;
@@ -40,9 +45,17 @@ public class CardPreviewController : MonoBehaviour
 
     private void Update()
     {
+        // A visible tutorial beat owns the screen. Without this, the tap that dismisses a
+        // beat also lands here, and closing the preview would unfreeze the battle running
+        // behind a modal beat.
+        if (BotTextTutorial.Instance != null && BotTextTutorial.Instance.IsBeatVisible)
+        {
+            return;
+        }
+
         if (isInPreview)
         {
-            if (Input.GetMouseButtonDown(0))
+            if (Input.GetMouseButtonDown(0) || HasTouchBegan())
             {
                 HidePreview();
                 clickTime = 0f;
@@ -56,7 +69,8 @@ public class CardPreviewController : MonoBehaviour
 
         if (Input.GetMouseButtonDown(0))
         {
-            if (Time.time - clickTime < doubleClickTimeThreshold)
+            // Unscaled: Time.time does not advance while the game is frozen.
+            if (Time.unscaledTime - clickTime < doubleClickTimeThreshold)
             {
                 GetObject(out currentObject);
                 //check if the objects doesn't changed between the clicks
@@ -70,7 +84,7 @@ public class CardPreviewController : MonoBehaviour
                 GetObject(out currentObject);
                 prevObject = currentObject;
             }
-            clickTime = Time.time;
+            clickTime = Time.unscaledTime;
         }
 
         if (Input.GetMouseButtonDown(1))
@@ -78,11 +92,70 @@ public class CardPreviewController : MonoBehaviour
             GetObject(out currentObject);
             SetPreview(currentObject);
         }
+
+        HandleTouchPreview();
+    }
+
+    /// <summary>Longest touch still counted as a tap rather than a fast-forward hold.</summary>
+    private const float MaxTapSeconds = 0.3f;
+
+    private readonly Dictionary<int, float> _touchStartTimes = new Dictionary<int, float>();
+
+    /// <summary>
+    /// Touch has no right-click, so a quick tap directly on a card opens its preview.
+    ///
+    /// Resolved on Ended and duration-limited: a held touch is the battle fast-forward gesture,
+    /// and previewing on Began would freeze the game the moment the player tried to speed it up.
+    /// Touch duration is tracked here because Touch.deltaTime is the time since the last frame,
+    /// not how long the finger has been down.
+    /// </summary>
+    private void HandleTouchPreview()
+    {
+        for (int i = 0; i < Input.touchCount; i++)
+        {
+            var touch = Input.GetTouch(i);
+
+            if (touch.phase == TouchPhase.Began)
+            {
+                _touchStartTimes[touch.fingerId] = Time.unscaledTime;
+                continue;
+            }
+
+            if (touch.phase != TouchPhase.Ended && touch.phase != TouchPhase.Canceled) continue;
+
+            var wasQuickTap = _touchStartTimes.TryGetValue(touch.fingerId, out var startedAt)
+                              && Time.unscaledTime - startedAt <= MaxTapSeconds;
+
+            _touchStartTimes.Remove(touch.fingerId);
+
+            if (touch.phase == TouchPhase.Canceled || !wasQuickTap) continue;
+
+            GetObject(out currentObject, touch.position);
+            if (currentObject != null)
+            {
+                SetPreview(currentObject);
+                return;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Touch devices have no right-click and no reliable double-click, so a begun touch is
+    /// treated as a preview gesture. Mouse emulation does not fire on every mobile browser,
+    /// which is why this is checked explicitly rather than relying on GetMouseButtonDown.
+    /// </summary>
+    private bool HasTouchBegan()
+    {
+        for (int i = 0; i < Input.touchCount; i++)
+        {
+            if (Input.GetTouch(i).phase == TouchPhase.Began) return true;
+        }
+        return false;
     }
 
     private void HidePreview()
     {
-        Time.timeScale = 1f;
+        TimeControl.Unfreeze(TimeControl.HolderCardPreview);
         isInPreview = false;
         previewPanel.SetActive(false);
         gameCard.SetActive(false);
@@ -91,10 +164,17 @@ public class CardPreviewController : MonoBehaviour
 
     private void GetObject(out GameObject currentObject)
     {
+        GetObject(out currentObject, Input.mousePosition);
+    }
+
+    private void GetObject(out GameObject currentObject, Vector2 screenPosition)
+    {
         currentObject = null;
 
+        if (EventSystem.current == null) return;
+
         PointerEventData pointerEventData = new PointerEventData(EventSystem.current);
-        pointerEventData.position = Input.mousePosition;
+        pointerEventData.position = screenPosition;
         List<RaycastResult> raycastResultList = new List<RaycastResult>(); 
         EventSystem.current.RaycastAll(pointerEventData, raycastResultList);
         for (int i = 0; i < raycastResultList.Count; i++)
@@ -144,7 +224,7 @@ public class CardPreviewController : MonoBehaviour
 
         previewPanel.SetActive(true);
 
-        Time.timeScale = 0f;
+        TimeControl.Freeze(TimeControl.HolderCardPreview);
     }
 
     private void SetPepemonCardPreview(PepemonCardController card)
@@ -170,6 +250,10 @@ public class CardPreviewController : MonoBehaviour
     private void SetCardPreview(CardController card)
     {
         _cardImg.sprite = card.HostedCard.CardEffectSprite;
+
+        if (_cardNameText != null) _cardNameText.text = card.HostedCard.DisplayName;
+        if (_cardDescriptionText != null) _cardDescriptionText.text = card.HostedCard.CardDescription;
+
         gameCard.SetActive(true);
     }
 

--- a/Assets/Scripts/Controllers/GameController.cs
+++ b/Assets/Scripts/Controllers/GameController.cs
@@ -14,6 +14,39 @@ using DG;
 using DG.Tweening;
 using Org.BouncyCastle.X509;
 using System.Reflection;
+using Pepemon.BattleRules;
+using Pepemon.Onboarding;
+using Pepemon.Telemetry;
+
+/// <summary>
+/// Timing of the battle presentation. Previously these were magic numbers scattered through
+/// the coroutines, which made the pacing untunable and left player 2's turn running twice as
+/// long as player 1's.
+/// </summary>
+[System.Serializable]
+public class BattlePacing
+{
+    public float preBattleDelay = 1.5f;
+    public float roundBannerSeconds = 1.2f;
+    public float bannerToDrawSeconds = 0.2f;
+    public float handSettleSeconds = 1f;
+
+    /// <summary>Time from cards lifting to the clash. Identical for both players by design.</summary>
+    public float liftToClashSeconds = 1f;
+
+    /// <summary>
+    /// Length of the clash. Must not be shorter than the Clash animation clip (1.667s) or the
+    /// tally icons are torn down mid-animation.
+    /// </summary>
+    public float clashToDamageSeconds = 1.7f;
+
+    public float damageHoldSeconds = 0.8f;
+    public float postDamageSeconds = 0.5f;
+    public float cardResetSeconds = 0.5f;
+
+    /// <summary>Multiplier applied while the player holds the fast-forward input.</summary>
+    public float fastForwardSpeed = 3f;
+}
 
 // Manages the automation of the game. Each round is composed of two hands being played (offense and defense)
 public class GameController : MonoBehaviour
@@ -21,6 +54,18 @@ public class GameController : MonoBehaviour
     private const int PLAYER1_SEED = 69;
     private const int PLAYER2_SEED = 420;
     private const int TIEBREAK_SEED = 69420;
+
+    /// <summary>
+    /// Fixed seed for the scripted first battle.
+    ///
+    /// The tutorial battle used to reseed from System.Random on every run, so the "guaranteed"
+    /// first win was actually just a stat mismatch that could and did lose. A constant seed
+    /// makes the battle identical for every player and therefore tunable.
+    ///
+    /// Retune with Pepemon > Simulate Tutorial Battles after changing either starter deck.
+    /// </summary>
+    private static readonly BigInteger TUTORIAL_BATTLE_SEED = BigInteger.Parse(
+        "68188038832262297884772284640717549873770515354422947402145954532168121309549");
 
     //Attacker can either be PLAYER_ONE or PLAYER_TWO
     private enum Attacker
@@ -53,22 +98,96 @@ public class GameController : MonoBehaviour
 
     [ReadOnly] private BigInteger battleSeed;
 
+    [TitleGroup("Pacing"), SerializeField] private BattlePacing pacing = new BattlePacing();
+
     [Header("StarterDeck")]
     public List<Card> starterDeck1;
     public List<Card> starterDeck2;
 
+    /// <summary>
+    /// True while the first battle must not be lost. Cleared once the starter pack has been
+    /// claimed, after which bot battles are ordinary fights.
+    /// </summary>
+    private bool _guaranteePlayerSurvives;
+
+    private bool _survivedOnOne;
+    private float _battleStartedAtUnscaled;
+
+    /// <summary>Unscaled time the current fast-forward hold began, or -1 when not held.</summary>
+    private float _holdStartedAtUnscaled = -1f;
+
+    private const float FastForwardHoldSeconds = 0.35f;
+
     private void Start()
     {
+        // Statics survive scene loads: clear any freeze or speed left over from the menu or
+        // from a previous battle exited mid-beat.
+        TimeControl.ResetAll();
+
         PrepareDecksBeforeBattle();
 
         player1Controller.PopulateCard(_player1.PlayerPepemon);
         player2Controller.PopulateCard(_player2.PlayerPepemon);
+
+        _guaranteePlayerSurvives =
+            BattlePrepController.battleData.isBotMatch && !OnboardingState.HasClaimedStarterPack;
+
+        _battleStartedAtUnscaled = Time.unscaledTime;
+
+        Funnel.Track(
+            Funnel.FirstBattleStarted,
+            "is_bot_match", BattlePrepController.battleData.isBotMatch,
+            "guaranteed_win", _guaranteePlayerSurvives);
 
         if (playAutomatically)
         {
             InitFirstRound();
             StartCoroutine(LoopGame());
         }
+    }
+
+    private void OnDestroy()
+    {
+        TimeControl.ResetAll();
+    }
+
+    /// <summary>
+    /// Hold to fast-forward. Only available from round 2 so the first round always plays at
+    /// full weight, and never while a tutorial beat is on screen so the input cannot be
+    /// consumed twice.
+    /// </summary>
+    private void Update()
+    {
+        if (_gameHasFinished || _roundNumber < 1)
+        {
+            if (!Mathf.Approximately(TimeControl.Speed, 1f)) TimeControl.SetSpeed(1f);
+            return;
+        }
+
+        if (BotTextTutorial.Instance != null && BotTextTutorial.Instance.IsBeatVisible)
+        {
+            TimeControl.SetSpeed(1f);
+            return;
+        }
+
+        bool inputDown = Input.GetKey(KeyCode.Space)
+                         || Input.GetMouseButton(0)
+                         || Input.touchCount > 0;
+
+        if (!inputDown)
+        {
+            _holdStartedAtUnscaled = -1f;
+            TimeControl.SetSpeed(1f);
+            return;
+        }
+
+        if (_holdStartedAtUnscaled < 0f) _holdStartedAtUnscaled = Time.unscaledTime;
+
+        // Must be a deliberate hold. A quick tap is the card-preview gesture, and speeding up
+        // on every stray tap would make the battle feel broken on touch.
+        bool held = Time.unscaledTime - _holdStartedAtUnscaled >= FastForwardHoldSeconds;
+
+        TimeControl.SetSpeed(held ? Mathf.Max(1f, pacing.fastForwardSpeed) : 1f);
     }
 
     /// <summary>
@@ -175,7 +294,10 @@ public class GameController : MonoBehaviour
         if (starterDeckID != 0)
         {
             PrepareSimulatedBattle(starterDeckID);
-            battleSeed = new System.Random().NextBigInteger();
+
+            // Fixed, not random: the first battle is authored content and must play out the
+            // same way for everyone. Reseeding here is what made the scripted win a coin flip.
+            battleSeed = TUTORIAL_BATTLE_SEED;
         }
         else
         {
@@ -235,7 +357,7 @@ public class GameController : MonoBehaviour
 
     IEnumerator LoopGame()
     {
-        yield return new WaitForSeconds(2f);
+        yield return new WaitForSeconds(pacing.preBattleDelay);
         while (!_gameHasFinished)
         {
             yield return new WaitUntil(() => !_isPlayingRound);
@@ -255,17 +377,12 @@ public class GameController : MonoBehaviour
         {
             yield return null;
         }
-        if (BattlePrepController.battleData.isBotMatch)
-        {
-            BotTextTutorial.Instance.TriggerTutorialEvent(1);
-        }
-        
-        //if (_roundNumber <= 1)
-        //   yield return new WaitForSeconds(1.2f);
+        TriggerTutorialBeat(TutorialScript.BeatIntro);
+
         _uiController.NewRoundDisplay();
-        yield return new WaitForSeconds(1.6f);
+        yield return new WaitForSeconds(pacing.roundBannerSeconds);
         _uiController.HideNewRoundDisplay();
-        yield return new WaitForSeconds(.3f);
+        yield return new WaitForSeconds(pacing.bannerToDrawSeconds);
 
         //Reset both players' hand infos to base stats
         _player1.ResetCurrentPepemonStats();
@@ -305,16 +422,14 @@ public class GameController : MonoBehaviour
         _uiController.DisplayHands();
 
         //delay to show drawing of cards
-        yield return new WaitForSeconds(1.5f); //3
+        yield return new WaitForSeconds(pacing.handSettleSeconds);
 
         //! need to think of a better way to display the cards being played
 
         _isPlayingRound = true;
         Debug.Log("<b>STARTING ROUND: </b>" + _roundNumber);
-        if (BattlePrepController.battleData.isBotMatch)
-        {
-            BotTextTutorial.Instance.TriggerTutorialEvent(2);
-        }
+
+        TriggerTutorialBeat(TutorialScript.BeatDraw);
 
         for (int i = 0; i < 2; i++)
         {
@@ -348,18 +463,22 @@ public class GameController : MonoBehaviour
                     player2Controller.ActivateCard(false);
 
                     //wait for animations showing the attacking/defending cards
-                    yield return new WaitForSeconds(1.5f); //3f
+                    yield return new WaitForSeconds(pacing.liftToClashSeconds);
 
-                    _uiController.StartCoroutine(_uiController.DisplayTotalValues(1, totalAttackPower, totalDefensePower));
+                    // Awaited. This used to be fire-and-forget while the caller waited a
+                    // shorter time, so the blur overlay was still up when the damage number
+                    // appeared underneath it.
+                    yield return _uiController.StartCoroutine(
+                        _uiController.DisplayTotalValues(1, totalAttackPower, totalDefensePower, pacing.clashToDamageSeconds));
 
-                    yield return new WaitForSeconds(1f); //1.5
-                    int dmg = totalAttackPower > totalDefensePower ? (totalAttackPower - totalDefensePower) : 1;
+                    int dmg = TutorialWinGuarantee.ResolveDamage(totalAttackPower, totalDefensePower);
 
                     _player2.CurrentHP -= dmg;
                     AttackDisplay(false, dmg);
                     healthBar2.TakeDamage(dmg);
+                    ApplyHitJuice(dmg, _player2.PlayerPepemon.HealthPoints);
 
-                    yield return new WaitForSeconds(1f); //1.5
+                    yield return new WaitForSeconds(pacing.damageHoldSeconds);
 
                     DisableAttackTexts();
 
@@ -376,17 +495,39 @@ public class GameController : MonoBehaviour
                     player1Controller.ActivateCard(false);
                     player2Controller.ActivateCard(true);
 
-                    yield return new WaitForSeconds(3f);
-                    _uiController.StartCoroutine(_uiController.DisplayTotalValues(2, totalAttackPower, totalDefensePower));
+                    // Same duration as player 1's turn. This branch used to wait 3s where the
+                    // other waited 1.5s, so the opponent's turns visibly dragged.
+                    yield return new WaitForSeconds(pacing.liftToClashSeconds);
 
-                    yield return new WaitForSeconds(1f); //1.5
-                    int dmg = totalAttackPower > totalDefensePower ? (totalAttackPower - totalDefensePower) : 1;
+                    yield return _uiController.StartCoroutine(
+                        _uiController.DisplayTotalValues(2, totalAttackPower, totalDefensePower, pacing.clashToDamageSeconds));
+
+                    int dmg = TutorialWinGuarantee.ResolveDamage(totalAttackPower, totalDefensePower);
+
+                    // First-battle safety net. The onboarding promises a guaranteed win, so the
+                    // player can be taken to the brink but not killed until they have claimed
+                    // the starter pack. Minimum damage is 1 in both directions, so the bot still
+                    // dies within a bounded number of rounds and the battle always terminates.
+                    if (_guaranteePlayerSurvives && TutorialWinGuarantee.IsLethal(_player1.CurrentHP, dmg))
+                    {
+                        dmg = TutorialWinGuarantee.ClampLethalDamage(_player1.CurrentHP, dmg, true);
+                        _survivedOnOne = true;
+                        Debug.Log("[tutorial] Lethal blow clamped - player survives on 1 HP.");
+                    }
 
                     _player1.CurrentHP -= dmg;
                     AttackDisplay(true, dmg);
                     healthBar1.TakeDamage(dmg);
+                    ApplyHitJuice(dmg, _player1.PlayerPepemon.HealthPoints);
 
-                    yield return new WaitForSeconds(1f); //1.5
+                    // Stakes beat, fired the moment the player is genuinely in trouble.
+                    if (_player1.PlayerPepemon.HealthPoints > 0 &&
+                        _player1.CurrentHP <= _player1.PlayerPepemon.HealthPoints * TutorialScript.ComebackHpThreshold)
+                    {
+                        TriggerTutorialBeat(TutorialScript.BeatComeback);
+                    }
+
+                    yield return new WaitForSeconds(pacing.damageHoldSeconds);
 
                     DisableAttackTexts();
 
@@ -399,21 +540,21 @@ public class GameController : MonoBehaviour
                 Debug.Log("goForBattle _player1.CurrentHP=" + _player1.CurrentHP);
                 Debug.Log("goForBattle _player2.CurrentHP=" + _player2.CurrentHP);
 
-                if (BattlePrepController.battleData.isBotMatch)
+                // Only after the player's own attack: the beat explains "your ATK minus their
+                // defense", which reads as nonsense straight after the opponent has swung.
+                if (_currentAttacker == Attacker.PLAYER_ONE)
                 {
-                    BotTextTutorial.Instance.TriggerTutorialEvent(3);
+                    TriggerTutorialBeat(TutorialScript.BeatDamage);
                 }
 
-                Debug.Log("waiting 2.5f");
-                yield return new WaitForSeconds(1f); //1.5
+                yield return new WaitForSeconds(pacing.postDamageSeconds);
 
                 // cleanup UI
                 _uiController.FlipCards(3);
                 player1Controller.DeActivateCard();
                 player2Controller.DeActivateCard();
-                Debug.Log(" after slow");
 
-                yield return new WaitForSeconds(1f); //1
+                yield return new WaitForSeconds(pacing.cardResetSeconds);
             }
         }
         Debug.Log("<b>FINISHED ROUND: </b>" + _roundNumber);
@@ -781,6 +922,21 @@ public class GameController : MonoBehaviour
         // when player1won=false and currentPlayerIsPlayer1=false, currentPlayerWon=true
         // because player2 won and current player is Player2
         var currentPlayerWon = player1won == BattlePrepController.battleData.currentPlayerIsPlayer1;
+
+        var maxHp = _player1.PlayerPepemon != null ? _player1.PlayerPepemon.HealthPoints : 0;
+
+        Funnel.Track(Funnel.FirstBattleEnded, new Dictionary<string, object>
+        {
+            ["won"] = currentPlayerWon,
+            ["rounds"] = GetRoundNumber(),
+            ["duration_s"] = Mathf.RoundToInt(Time.unscaledTime - _battleStartedAtUnscaled),
+            ["final_hp_pct"] = maxHp > 0 ? Mathf.RoundToInt(100f * _player1.CurrentHP / maxHp) : 0,
+            ["is_bot_match"] = BattlePrepController.battleData.isBotMatch,
+            ["survived_on_one"] = _survivedOnOne
+        });
+
+        TimeControl.SetSpeed(1f);
+
         _uiController.DisplayBattleResult(winner, currentPlayerWon);
         _gameHasFinished = true;
     }
@@ -797,23 +953,55 @@ public class GameController : MonoBehaviour
 
     private void AttackDisplay(bool isPlayer1, int dmg)
     {
-        if (isPlayer1)
-        {
-            dmgText1.text = "-" + dmg.ToString();
-            dmgText1.DOFade(1f, 1.5f);
-        }
-        else
-        {
-            dmgText2.text = "-" + dmg.ToString();
-            dmgText2.DOFade(1f, 1.5f);
-        }
+        // A fully blocked hit has nothing to report. Only reachable via the tutorial clamp.
+        if (dmg <= 0) return;
 
-        SFXManager.Instance.HitSFX();
+        var label = isPlayer1 ? dmgText1 : dmgText2;
+        if (label == null) return;
+
+        label.text = "-" + dmg.ToString();
+
+        // Was a 1.5s fade-in held for only 1s before being faded back out, so the damage
+        // number never actually reached full opacity. It should land, not drift in.
+        DOTween.Kill(label);
+        label.DOFade(1f, 0.12f);
     }
 
     private void DisableAttackTexts()
     {
-        dmgText1.DOFade(0f, 1f);
-        dmgText2.DOFade(0f, 1f);
+        if (dmgText1 != null) dmgText1.DOFade(0f, 0.35f);
+        if (dmgText2 != null) dmgText2.DOFade(0f, 0.35f);
+    }
+
+    /// <summary>
+    /// Shows a tutorial beat. Null-safe and bot-match-gated: the battle must still run if the
+    /// tutorial object is absent from the scene.
+    /// </summary>
+    private void TriggerTutorialBeat(int beatId)
+    {
+        if (!BattlePrepController.battleData.isBotMatch) return;
+
+        // The killing blow can land before a beat's trigger point is reached. Once the battle
+        // is over the post-battle screen owns the display, so no beat may appear on top of it.
+        if (_gameHasFinished) return;
+
+        if (BotTextTutorial.Instance == null) return;
+
+        BotTextTutorial.Instance.TriggerTutorialEvent(beatId);
+    }
+
+    /// <summary>Impact feedback scaled to how hard the hit landed relative to max HP.</summary>
+    private void ApplyHitJuice(int dmg, int maxHp)
+    {
+        if (dmg <= 0) return;
+
+        var severity = maxHp > 0 ? Mathf.Clamp01(dmg / (float)maxHp) : 0f;
+
+        if (_uiController != null) _uiController.ShakeBoard(severity);
+
+        if (SFXManager.Instance == null) return;
+
+        if (severity >= 0.25f) SFXManager.Instance.BigHitSFX();
+        else SFXManager.Instance.HitSFX();
     }
 }

--- a/Assets/Scripts/Controllers/MainMenuController.cs
+++ b/Assets/Scripts/Controllers/MainMenuController.cs
@@ -152,18 +152,61 @@ public class MainMenuController : MonoBehaviour
                 return;
             }
 
-            SetClaimStatus("Minting your cards...");
-            await PepemonCardDeck.MintCards();
+            // The choice is read from persisted state, not Web3Controller: the post-battle
+            // screen zeroes StarterPepemonID/StarterDeckID before this scene loads.
+            var pepemonId = OnboardingState.PendingStarterPepemonId;
+            if (pepemonId <= 0)
+            {
+                Debug.LogWarning("[claim] No starter Pepemon recorded, defaulting to Fafny.");
+                pepemonId = 1;
+            }
 
-            SetClaimStatus("Creating your deck...");
-            await PepemonCardDeck.CreateDeck();
+            var starterDeckId = (ulong)OnboardingState.PendingStarterDeckId;
 
-            // Only now is the promise actually kept.
+            // Include inactive: the prep controller lives on a menu screen that is not the
+            // one currently shown.
+            var prep = FindObjectOfType<BattlePrepController>(true);
+            var supportCardIds = prep != null
+                ? prep.GetStarterSupportCardIds(starterDeckId)
+                : new List<ulong>();
+
+            if (prep == null)
+            {
+                Debug.LogWarning("[claim] BattlePrepController not found; deck will be created without support cards.");
+            }
+
+            var result = await StarterPackClaim.Run((ulong)pepemonId, supportCardIds, SetClaimStatus);
+
+            Funnel.Track(Funnel.MintResult, new Dictionary<string, object>
+            {
+                ["success"] = result.AssetsGranted,
+                ["deck_playable"] = result.DeckIsPlayable,
+                ["support_cards"] = result.SupportCardsAdded,
+                ["battle_card_set"] = result.BattleCardSet,
+                ["error"] = result.Error ?? string.Empty
+            });
+
+            if (!result.AssetsGranted)
+            {
+                // Nothing irreversible happened, so leave the claim available to retry.
+                FailClaim(result.Error ?? "unknown", "Claim failed. Try again from the Deck screen.");
+                return;
+            }
+
+            // The faucet has fired and cannot be undone - re-running it would mint twice.
+            // Record the claim even if assembly failed, and tell the player what is left to do.
             OnboardingState.HasClaimedStarterPack = true;
             claimedStarterDeck = true;
 
-            Funnel.Track(Funnel.MintResult, "success", true);
-            SetClaimStatus("Starter pack claimed!");
+            SetClaimStatus(result.DeckIsPlayable
+                ? "Starter pack claimed - your deck is ready!"
+                : "Cards minted. Finish your deck in the Deck screen.");
+
+            if (!result.DeckIsPlayable)
+            {
+                Debug.LogWarning($"[claim] Deck not fully assembled: battleCard={result.BattleCardSet} " +
+                                 $"supportCards={result.SupportCardsAdded} error={result.Error}");
+            }
 
             // Explicit null check rather than ?. - Unity's fake-null does not short-circuit.
             if (_screenManageDecks != null) _screenManageDecks.ReloadAllDecks();

--- a/Assets/Scripts/Controllers/MainMenuController.cs
+++ b/Assets/Scripts/Controllers/MainMenuController.cs
@@ -1,5 +1,9 @@
+using System;
 using System.Collections.Generic;
 using Cysharp.Threading.Tasks;
+using Pepemon.Battle;
+using Pepemon.Onboarding;
+using Pepemon.Telemetry;
 using Scripts.Managers.Sound;
 using Sirenix.OdinInspector;
 using Thirdweb;
@@ -34,17 +38,28 @@ public class MainMenuController : MonoBehaviour
 
     public static bool claimedStarterDeck = false;
 
+    /// <summary>Optional status label for the starter-pack claim. Null-safe when unwired.</summary>
+    [SerializeField] private GameObject _claimStatusMessage;
+
     private void Start()
     {
         Application.targetFrameRate = 60;
         Screen.sleepTimeout = SleepTimeout.NeverSleep;
+
+        // Clear any freeze left behind by leaving the battle scene mid-tutorial or mid-preview,
+        // which would otherwise hold this scene at timeScale 0.
+        TimeControl.ResetAll();
+
+        Funnel.Track(Funnel.AppLoaded);
 
         //PostBattleScreenController.IsClaimingGift = true; //- for testing the gift mechanic with the deck manager
         // TODO: find a better way to handle re-loading the main scene
 
         HandleGoingBackToMenu();
         _connectWalletButton.onClick.AddListener(OnConnectWalletButtonClick);
-        _mintDeckButton.onClick.AddListener(OnConnectWalletButtonClick);
+        // Note: _mintDeckButton is intentionally not wired to OnConnectWalletButtonClick here.
+        // MintDeckButtonHandler already connects the wallet as part of its own flow, and having
+        // both listeners on one button fired two concurrent ConnectWallet() calls per click.
         _startGameButton.onClick.AddListener(OnStartGameButtonClick);
         _manageDecksButton.onClick.AddListener(OnManageDecksButtonClick);
         _leaderboardButton.onClick.AddListener(OnLeaderboardButtonClick);
@@ -80,11 +95,102 @@ public class MainMenuController : MonoBehaviour
         }
     }
 
-    private void ClaimStarterDeck()
+    /// <summary>
+    /// Mints the player's starter pack.
+    ///
+    /// This used to be a stub that logged an error and set the "claimed" flag anyway, so the
+    /// player connected a wallet - the highest-friction step in the funnel - and received
+    /// nothing, permanently marked as having claimed.
+    ///
+    /// Two transactions, using the same permissionless faucet the edit-deck screen already
+    /// ships: mintCards() grants the cards, createDeck() grants the deck NFT to hold them.
+    /// Assembling the chosen starter into that deck needs approval plus two more writes and
+    /// is deferred until the on-chain card ids are confirmed to match the local ScriptableObjects.
+    ///
+    /// The claimed flag is only set after both transactions confirm. A rejected or reverted
+    /// claim leaves the player claimable, so replaying the bot battle offers CLAIM again.
+    /// </summary>
+    private async void ClaimStarterDeck()
     {
-        Debug.LogError("gift claim is not yet implemented");
-        PlayerPrefs.SetInt("GotStarterPack", 1);
-        //claimedStarterDeck = true;
+        if (OnboardingState.HasClaimedStarterPack)
+        {
+            Debug.Log("[claim] Starter pack already claimed, nothing to do.");
+            return;
+        }
+
+        Funnel.Track(Funnel.ClaimClicked);
+        SetClaimStatus("Claiming your starter pack...");
+
+        try
+        {
+            if (Web3Controller.instance == null)
+            {
+                FailClaim("no_web3_controller", "Wallet unavailable. Try again from the Deck screen.");
+                return;
+            }
+
+            if (!Web3Controller.instance.IsConnected)
+            {
+                SetClaimStatus("Connecting wallet...");
+                Funnel.Track(Funnel.WalletConnectRequested);
+                await Web3Controller.instance.ConnectWallet();
+            }
+
+            if (!Web3Controller.instance.IsConnected)
+            {
+                Funnel.Track(Funnel.WalletConnectResult, "success", false, "error", "not_connected");
+                FailClaim("wallet_not_connected", "Wallet not connected. Try again from the Deck screen.");
+                return;
+            }
+
+            Funnel.Track(Funnel.WalletConnectResult, "success", true);
+
+            var address = await ThirdwebManager.Instance.SDK.Wallet.GetAddress();
+            if (string.IsNullOrEmpty(address))
+            {
+                FailClaim("no_address", "No wallet address found. Try again from the Deck screen.");
+                return;
+            }
+
+            SetClaimStatus("Minting your cards...");
+            await PepemonCardDeck.MintCards();
+
+            SetClaimStatus("Creating your deck...");
+            await PepemonCardDeck.CreateDeck();
+
+            // Only now is the promise actually kept.
+            OnboardingState.HasClaimedStarterPack = true;
+            claimedStarterDeck = true;
+
+            Funnel.Track(Funnel.MintResult, "success", true);
+            SetClaimStatus("Starter pack claimed!");
+
+            // Explicit null check rather than ?. - Unity's fake-null does not short-circuit.
+            if (_screenManageDecks != null) _screenManageDecks.ReloadAllDecks();
+        }
+        catch (Exception e)
+        {
+            Funnel.Track(Funnel.MintResult, "success", false, "error", e.Message);
+            FailClaim(e.Message, "Claim failed. Try again from the Deck screen.");
+        }
+    }
+
+    private void FailClaim(string reason, string userMessage)
+    {
+        Debug.LogError($"[claim] Starter pack claim failed: {reason}");
+        SetClaimStatus(userMessage);
+    }
+
+    private void SetClaimStatus(string message)
+    {
+        Debug.Log($"[claim] {message}");
+
+        if (_claimStatusMessage == null) return;
+
+        _claimStatusMessage.SetActive(!string.IsNullOrEmpty(message));
+
+        var label = _claimStatusMessage.GetComponent<TMPro.TMP_Text>();
+        if (label != null) label.text = message;
     }
 
     private async void DeInitMainScene(bool toLoadScreen)
@@ -192,6 +298,10 @@ public class MainMenuController : MonoBehaviour
 
     public void OnStartGameButtonClick()
     {
+        Funnel.Track(
+            Funnel.StartPressed,
+            "connected", Web3Controller.instance != null && Web3Controller.instance.IsConnected);
+
         ShowScreen(MainSceneScreensEnum.LeagueSelection);
     }
 

--- a/Assets/Scripts/Controllers/PepemonCardController.cs
+++ b/Assets/Scripts/Controllers/PepemonCardController.cs
@@ -83,7 +83,9 @@ public class PepemonCardController : MonoBehaviour
 
     public void ActivateCard(bool isAttacker)
     {
-        if (BotTextTutorial.Instance.IsInTutorial)
+        // Null-safe: the battle scene must still run without the tutorial component, and this
+        // is reached from a coroutine that can outlive it.
+        if (BotTextTutorial.Instance != null && BotTextTutorial.Instance.IsInTutorial)
             return;
 
         Color color = isAttacker ? Color.red : Color.cyan;

--- a/Assets/Scripts/Controllers/PostBattleScreenController.cs
+++ b/Assets/Scripts/Controllers/PostBattleScreenController.cs
@@ -9,6 +9,8 @@ using UnityEngine.UI;
 using UnityEngine.SceneManagement;
 using Scripts.Managers.Sound;
 using Pepemon.Battle;
+using Pepemon.Onboarding;
+using Pepemon.Telemetry;
 using Cysharp.Threading.Tasks.Triggers;
 
 [RequireComponent(typeof(CanvasGroup)), RequireComponent(typeof(Animator))]
@@ -25,9 +27,11 @@ public class PostBattleScreenController : MonoBehaviour
     protected const string DEFEAT_TEXT = "DEFEAT";
     protected const string YOU_LOSE_TEXT = "YOU LOSE";
 
-    protected const string RANKING_GAIN = "Gained +#pts";
-    protected const string RANKING_LOSS = "Lost -#pts";
+    /// <summary>How long to wait for the wallet before letting the player retry the claim.</summary>
+    protected const float ClaimConnectTimeoutSeconds = 45f;
     #endregion
+
+    private float _claimWaitStartedAtUnscaled;
 
     #region Editor Exposed Data
     [Title("Screen Settings")]
@@ -81,43 +85,61 @@ public class PostBattleScreenController : MonoBehaviour
         _winDisplay.SetActive(win);
         _loseDisplay.SetActive(!win);
 
-        // TODO: replace this with the actual gain/loss
-
         bool isBotMatch = BattlePrepController.battleData.isBotMatch;
-        bool isTutorial = BotTextTutorial.Instance.wasInTutorial;
-        bool claimedStarterPack = PlayerPrefs.GetInt("GotStarterPack", 0) == 1;
+        bool claimedStarterPack = OnboardingState.HasClaimedStarterPack;
+        bool starterPackOnOffer = isBotMatch && !claimedStarterPack;
 
-        if (isTutorial || claimedStarterPack)
+        // The reward line previously read a hardcoded "Gained +10pts". No ranking is written
+        // on-chain for bot matches, and the client never reads the real ELO delta for PvP
+        // either, so that number was invented. Show only what is actually true: for the first
+        // battle the reward is the starter pack, which is now really minted.
+        SetRewardText(win && starterPackOnOffer ? "Starter Pack unlocked" : string.Empty);
+
+        var winText = isBotMatch ? TutorialScript.WinHeadline + " " : "You won! ";
+        var loseText = isBotMatch ? TutorialScript.RivalName + " took that one. " : "You lost! ";
+
+        if (starterPackOnOffer)
         {
-            _rewardDisplay.GetComponentInChildren<TextReveal>()
-            .SetText((win ? RANKING_GAIN : RANKING_LOSS).Replace("#", "10"));
+            winText += TutorialScript.WinSubline;
+            loseText += TutorialScript.LoseSubline;
         }
         else
         {
-            _rewardDisplay.SetActive(false);
-            _rewardDisplay.GetComponentInChildren<TextReveal>()
-            .SetText(win && !claimedStarterPack ? "Gained Starter Pack" : "");
+            winText += "- Score will be updated in Leaderboards";
+            loseText += "- Better luck next time";
         }
 
-        _winMsg.GetComponent<TMPro.TMP_Text>().text = "You won! ";
-        _loseMsg.GetComponent<TMPro.TMP_Text>().text = "You lost! ";
+        SetLabel(_winMsg, winText);
+        SetLabel(_loseMsg, loseText);
 
-        _btnClaimGift.gameObject.SetActive(isBotMatch && !claimedStarterPack);
-        /*
-        bool winMsgShouldBeDisplayed = ((isBotMatch && claimedStarterPack) || !isBotMatch) && win;
-        _winMsg.SetActive(winMsgShouldBeDisplayed);
-        bool loseMsgShouldBeDisplayed = ((isBotMatch && claimedStarterPack) || !isBotMatch) && !win;
-        _loseMsg.SetActive(loseMsgShouldBeDisplayed);
-        */
-
-        _winMsg.GetComponent<TMPro.TMP_Text>().text += (isBotMatch && !claimedStarterPack) ? "claim your starter pack" : "- Score will be updated in Leaderboards";
-        //_starterPackMsg.SetActive(isBotMatch && !claimedStarterPack);
-        _loseMsg.GetComponent<TMPro.TMP_Text>().text += (isBotMatch && !claimedStarterPack) ? "claim your starter pack" : "- Better luck next time";
-        //_starterPackMsg2.SetActive(isBotMatch && !claimedStarterPack);
+        _btnClaimGift.gameObject.SetActive(starterPackOnOffer);
         _btnShowMenu.gameObject.SetActive(true);
-        _btnPlayAgain.gameObject.SetActive((isBotMatch && claimedStarterPack) || !isBotMatch);
+        _btnPlayAgain.gameObject.SetActive(!starterPackOnOffer);
 
-        ThemePlayer.Instance.PlayGameOverSong(win);
+        if (ThemePlayer.Instance != null) ThemePlayer.Instance.PlayGameOverSong(win);
+    }
+
+    private static void SetLabel(GameObject host, string text)
+    {
+        if (host == null) return;
+
+        var label = host.GetComponent<TMPro.TMP_Text>();
+        if (label != null) label.text = text;
+    }
+
+    private void SetRewardText(string text)
+    {
+        if (_rewardDisplay == null) return;
+
+        var hasText = !string.IsNullOrEmpty(text);
+
+        // Set the text before hiding: GetComponentInChildren skips inactive objects by
+        // default, so the previous order wrote to a null reference whenever the display
+        // had already been deactivated.
+        var reveal = _rewardDisplay.GetComponentInChildren<TextReveal>(true);
+        if (reveal != null) reveal.SetText(text);
+
+        _rewardDisplay.SetActive(hasText);
     }
 
     public void LoadPepemonDisplay(ulong cardId)
@@ -143,38 +165,74 @@ public class PostBattleScreenController : MonoBehaviour
 
     public void OnBtnShowMenuClick()
     {
-        // go back to previous scene
-        IsGoingFromBattle = true;
-
-        //reset the bot battle values
-        Web3Controller.instance.StarterDeckID = 0;
-        Web3Controller.instance.StarterPepemonID = 0;
-
-        int currentSceneIndex = SceneManager.GetActiveScene().buildIndex;
-        SceneManager.LoadScene(currentSceneIndex - 1);
+        Funnel.Track(Funnel.ReturnedToMenu);
+        GoToMenuScene();
     }
-    
+
     public void OnBtnClaimGiftClick()
     {
-        // go back to previous scene
         IsGoingFromBattle = true;
         IsClaimingGift = true;
 
-        if (!Web3Controller.instance.IsConnected)
+        Funnel.Track(Funnel.ClaimClicked, "from", "post_battle");
+
+        // Guard against a second click while the wallet prompt is open.
+        if (_btnClaimGift != null) _btnClaimGift.interactable = false;
+
+        if (Web3Controller.instance != null && !Web3Controller.instance.IsConnected)
         {
+            Funnel.Track(Funnel.WalletConnectRequested);
             Web3Controller.instance.ConnectWallet();
         }
 
+        _claimWaitStartedAtUnscaled = Time.unscaledTime;
         InvokeRepeating(nameof(CheckIfWalletConnected), 0.5f, 0.3f);
     }
 
+    /// <summary>
+    /// Polls for the wallet connection kicked off by the claim button.
+    ///
+    /// This used to run forever: it never cancelled itself, so once connected it called
+    /// LoadScene every 0.3s until the scene finally unloaded, and if the player dismissed
+    /// the wallet prompt it polled for the rest of the session with no way out.
+    /// </summary>
     private void CheckIfWalletConnected()
     {
-        if (Web3Controller.instance.IsConnected)
+        if (Web3Controller.instance != null && Web3Controller.instance.IsConnected)
         {
-            int currentSceneIndex = SceneManager.GetActiveScene().buildIndex;
-            SceneManager.LoadScene(currentSceneIndex - 1);
+            CancelInvoke(nameof(CheckIfWalletConnected));
+            Funnel.Track(Funnel.WalletConnectResult, "success", true);
+            GoToMenuScene();
+            return;
         }
+
+        if (Time.unscaledTime - _claimWaitStartedAtUnscaled < ClaimConnectTimeoutSeconds) return;
+
+        CancelInvoke(nameof(CheckIfWalletConnected));
+
+        // Stay on this screen so the claim is still reachable rather than silently lost.
+        IsClaimingGift = false;
+        IsGoingFromBattle = false;
+
+        Funnel.Track(Funnel.WalletConnectResult, "success", false, "error", "timeout");
+        SetLabel(_winMsg, "Wallet not connected - tap CLAIM to try again.");
+
+        if (_btnClaimGift != null) _btnClaimGift.interactable = true;
+    }
+
+    private void GoToMenuScene()
+    {
+        IsGoingFromBattle = true;
+
+        // Reset the bot battle values so the next START goes to the real game.
+        if (Web3Controller.instance != null)
+        {
+            Web3Controller.instance.StarterDeckID = 0;
+            Web3Controller.instance.StarterPepemonID = 0;
+        }
+
+        int currentSceneIndex = SceneManager.GetActiveScene().buildIndex;
+        SceneManager.LoadScene(currentSceneIndex - 1);
     }
 
     #region INIT

--- a/Assets/Scripts/Controllers/StartDeckChooseController.cs
+++ b/Assets/Scripts/Controllers/StartDeckChooseController.cs
@@ -1,9 +1,23 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using Pepemon.Battle;
+using Pepemon.Telemetry;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
+/// <summary>
+/// The starter-selection screen.
+///
+/// This is the only real decision a player makes before an automatic battle, so it carries all
+/// of the pre-battle agency. It previously showed a name and a sentence and no stats at all -
+/// while the very next screen lectured the player about ATK, DEF, SPD and INT.
+///
+/// The buttons in StartScreen.unity still drive this through SetName/SetDesc. When
+/// <see cref="cardsData"/> is wired, the name is used to look up the Pepemon and the stat block
+/// and authored copy come from the ScriptableObject instead of scene-embedded strings.
+/// </summary>
 public class StartDeckChooseController : MonoBehaviour
 {
     [SerializeField] private Image currentPepemonImg;
@@ -11,23 +25,76 @@ public class StartDeckChooseController : MonoBehaviour
     [SerializeField] private TMP_Text descDisplay;
     [SerializeField] private Button defaultSetting;
 
+    [Header("Stat block - optional, null-safe until wired")]
+    [SerializeField] private DataContainer cardsData;
+    [SerializeField] private TMP_Text hpText;
+    [SerializeField] private TMP_Text atkText;
+    [SerializeField] private TMP_Text defText;
+    [SerializeField] private TMP_Text spdText;
+    [SerializeField] private TMP_Text intText;
+    [SerializeField] private TMP_Text taglineText;
+
+    private string _selectedName;
+
     private void Start()
     {
-        defaultSetting.onClick.Invoke();
+        // Load-bearing: this is what sets Web3Controller.StarterPepemonID, so the battle scene
+        // has a Pepemon even if the player presses START without touching either option.
+        if (defaultSetting != null) defaultSetting.onClick.Invoke();
     }
 
     public void SetImg(Sprite sprite)
     {
-        currentPepemonImg.sprite = sprite;
+        if (currentPepemonImg != null) currentPepemonImg.sprite = sprite;
     }
 
     public void SetName(string name)
     {
-        pepemonName.text = name;
+        _selectedName = name;
+
+        if (pepemonName != null) pepemonName.text = name;
+
+        Funnel.Track(Funnel.PepemonSelected, "name", name);
+
+        ShowStatsFor(name);
     }
 
     public void SetDesc(string desc)
     {
-        descDisplay.text = desc;
+        // Authored copy on the ScriptableObject wins over the string embedded in the scene.
+        var pepemon = FindPepemonByName(_selectedName);
+        if (pepemon != null && !string.IsNullOrEmpty(pepemon.Description))
+        {
+            desc = pepemon.Description;
+        }
+
+        if (descDisplay != null) descDisplay.text = desc;
+    }
+
+    private void ShowStatsFor(string name)
+    {
+        var pepemon = FindPepemonByName(name);
+        if (pepemon == null) return;
+
+        SetStat(hpText, pepemon.HealthPoints);
+        SetStat(atkText, pepemon.Attack);
+        SetStat(defText, pepemon.Defense);
+        SetStat(spdText, pepemon.Speed);
+        SetStat(intText, pepemon.Intelligence);
+
+        if (taglineText != null) taglineText.text = pepemon.Tagline;
+    }
+
+    private BattleCard FindPepemonByName(string name)
+    {
+        if (cardsData == null || cardsData.Pepemons == null || string.IsNullOrEmpty(name)) return null;
+
+        return cardsData.Pepemons.FirstOrDefault(
+            p => p != null && string.Equals(p.DisplayName, name, System.StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static void SetStat(TMP_Text label, int value)
+    {
+        if (label != null) label.text = value.ToString();
     }
 }

--- a/Assets/Scripts/Controllers/UIController.cs
+++ b/Assets/Scripts/Controllers/UIController.cs
@@ -4,7 +4,9 @@ using TMPro;
 using UnityEngine.UI;
 using System.Collections.Generic;
 using System.Collections;
+using DG.Tweening;
 using Pepemon.Battle;
+using Pepemon.Onboarding;
 using static UnityEngine.ParticleSystem;
 using System.Reflection;
 // Handles displaying game state
@@ -41,7 +43,13 @@ public class UIController : MonoBehaviour
 
     [SerializeField, BoxGroup("Effects")] GameObject _attackTallyPS;         //the effect spawned by the card when tally the defense/attack amount
 
+    [TitleGroup("Pacing"), SerializeField] float _cardDealStagger = 0.15f;
+    [TitleGroup("Pacing"), SerializeField] float _cardFlipStagger = 0.22f;
+
     [TitleGroup("Post battle control"), SerializeField] PostBattleScreenController PostScreenController;
+
+    /// <summary>Colour of a card that is not being played this turn.</summary>
+    private static readonly Color DimmedCardColor = new Color(0.45f, 0.45f, 0.45f, 1f);
 
     Player _player1;
     Player _player2;
@@ -53,7 +61,9 @@ public class UIController : MonoBehaviour
     {
         _player1 = player1;
         _player2 = player2;
-        _sidebar = GameObject.Find("Sidebar").transform;
+
+        var sidebarGo = GameObject.Find("Sidebar");
+        _sidebar = sidebarGo != null ? sidebarGo.transform : null;
 
         UpdateUI();
 
@@ -72,7 +82,12 @@ public class UIController : MonoBehaviour
         string rN = player2.PlayerPepemon.DisplayName;
         string bN = player1.PlayerPepemon.DisplayName;
 
-        _versusScreen.SetVersusScreen(imgR, imgB, bgB, bgR, bN, rN);
+        // In the first battle the opponent is a named rival rather than an anonymous bot.
+        string taunt = BattlePrepController.battleData.isBotMatch
+            ? $"{TutorialScript.RivalName}: \"{TutorialScript.RivalTaunt}\""
+            : null;
+
+        _versusScreen.SetVersusScreen(imgR, imgB, bgB, bgR, bN, rN, taunt);
     }
 
     public void NewRoundDisplay()
@@ -115,7 +130,7 @@ public class UIController : MonoBehaviour
         for (int i = 0; i < _whichPlayer.CurrentHand.GetCardsInHand.Count; i++)
         {
             //delay between each card spawn for effect
-            yield return new WaitForSeconds(.2f);
+            yield return new WaitForSeconds(_cardDealStagger);
             GameObject go = new GameObject("Card Container", typeof(RectTransform));
             GameObject card;
             if (_whichPlayer == _player1) card = Instantiate(_cardPrefab, _deck2Transform.position, Quaternion.identity);
@@ -132,7 +147,7 @@ public class UIController : MonoBehaviour
             if (_whichPlayer == _player1) _player1Cards.Add(card.GetComponent<CardController>());
             else _player2Cards.Add(card.GetComponent<CardController>());
 
-            SFXManager.Instance.DealSFX();
+            if (SFXManager.Instance != null) SFXManager.Instance.DealSFX();
         }
     }
 
@@ -143,82 +158,78 @@ public class UIController : MonoBehaviour
     }
 
 
-    // disables cards based on attacking or defending
+    /// <summary>
+    /// Lifts the cards actually played this turn and dims the rest.
+    ///
+    /// This previously greyed the played cards - the opposite of the intended emphasis - and
+    /// never restored the colour, so every card in the battle was permanently grey after the
+    /// first turn. Now the played cards are the only ones at full colour, which doubles as
+    /// the spotlight the tutorial needs when it explains what support cards do.
+    /// </summary>
     public IEnumerator FlipCardsRoutine(int attackIndex)
     {
-        if (attackIndex == 1) // p1
+        if (attackIndex == 3) // reset
         {
-            for (int i = 0; i < _player1Cards.Count; i++)
-            {
-                if (_player1Cards[i].HostedCard.IsAttackingCard() != false)
-                {
-                    _player1Cards[i].SetAttackingTransform(new Vector3(0, 5f, 0));
-                    _player1Cards[i].GetComponent<Image>().color = Color.gray;
+            foreach (var card in _player2Cards) ResetCard(card);
+            foreach (var card in _player1Cards) ResetCard(card);
 
-                    yield return new WaitForSeconds(0.3f);
-                }
-            }
-
-            for (int i = 0; i < _player2Cards.Count; i++)
-            {
-                if (_player2Cards[i].HostedCard.IsAttackingCard() != true)
-                {
-                    _player2Cards[i].SetAttackingTransform(new Vector3(0, 5f, 0));
-                    _player2Cards[i].GetComponent<Image>().color = Color.gray;
-
-                    yield return new WaitForSeconds(0.3f);
-                }
-            }
-        }
-        else if (attackIndex == 2) // p2
-        {
-            for (int i = 0; i < _player2Cards.Count; i++)
-            {
-                if (_player2Cards[i].HostedCard.IsAttackingCard() != false)
-                {
-                    _player2Cards[i].SetAttackingTransform(new Vector3(0, 5f, 0));
-
-                    _player2Cards[i].GetComponent<Image>().color = Color.gray;
-
-                    yield return new WaitForSeconds(0.3f);
-                }
-            }
-
-            for (int i = 0; i < _player1Cards.Count; i++)
-            {
-                if (_player1Cards[i].HostedCard.IsAttackingCard() != true)
-                {
-                    _player1Cards[i].SetAttackingTransform(new Vector3(0, 5f, 0));
-
-                    _player1Cards[i].GetComponent<Image>().color = Color.gray;
-
-                    yield return new WaitForSeconds(0.3f);
-                }
-            }
-        }
-        else if (attackIndex == 3) // reset cards
-        {
-            for (int i = 0; i < _player2Cards.Count; i++)
-            {
-                _player2Cards[i].ReturnToBaseTransform();
-
-                _player2Cards[i].GetComponent<Image>().color = Color.gray;
-
-                yield return new WaitForSeconds(0.1f);
-            }
-
-            for (int i = 0; i < _player1Cards.Count; i++)
-            {
-                _player1Cards[i].ReturnToBaseTransform();
-
-                _player1Cards[i].GetComponent<Image>().color = Color.gray;
-
-                yield return new WaitForSeconds(0.1f);
-            }
+            BringSidebarToFront();
+            yield break;
         }
 
+        var attackerCards = attackIndex == 1 ? _player1Cards : _player2Cards;
+        var defenderCards = attackIndex == 1 ? _player2Cards : _player1Cards;
+
+        foreach (var card in attackerCards) SetCardHighlight(card, false);
+        foreach (var card in defenderCards) SetCardHighlight(card, false);
+
+        // The attacker plays its offense cards.
+        foreach (var card in attackerCards)
+        {
+            if (card == null || card.HostedCard == null || !card.HostedCard.IsAttackingCard()) continue;
+
+            card.SetAttackingTransform(new Vector3(0, 5f, 0));
+            SetCardHighlight(card, true);
+
+            yield return new WaitForSeconds(_cardFlipStagger);
+        }
+
+        // The defender answers with its defense cards.
+        foreach (var card in defenderCards)
+        {
+            if (card == null || card.HostedCard == null || card.HostedCard.IsAttackingCard()) continue;
+
+            card.SetAttackingTransform(new Vector3(0, 5f, 0));
+            SetCardHighlight(card, true);
+
+            yield return new WaitForSeconds(_cardFlipStagger);
+        }
+
+        BringSidebarToFront();
+    }
+
+    private static void ResetCard(CardController card)
+    {
+        if (card == null) return;
+
+        card.ReturnToBaseTransform();
+        SetCardHighlight(card, true);
+    }
+
+    private static void SetCardHighlight(CardController card, bool highlighted)
+    {
+        if (card == null) return;
+
+        var image = card.GetComponent<Image>();
+        if (image == null) return;
+
+        image.color = highlighted ? Color.white : DimmedCardColor;
+    }
+
+    private void BringSidebarToFront()
+    {
         // Make pepemon card, stage & hp points appear in front of support cards
-        _sidebar.SetAsLastSibling();
+        if (_sidebar != null) _sidebar.SetAsLastSibling();
     }
 
     /// <summary>
@@ -228,7 +239,7 @@ public class UIController : MonoBehaviour
     /// <param name="_totalAttack"></param>
     /// <param name="_totalDef"></param>
     /// <returns></returns>
-    public IEnumerator DisplayTotalValues(int attackIndex, int _totalAttack, int _totalDef)
+    public IEnumerator DisplayTotalValues(int attackIndex, int _totalAttack, int _totalDef, float clashSeconds = 1.5f)
     {
         //display the proper attack and defend symbols
         if (attackIndex == 1)
@@ -256,14 +267,30 @@ public class UIController : MonoBehaviour
 
         _blurryScreen.SetActive(true);
 
-        yield return new WaitForSeconds(2.5f);
+        // The caller now awaits this routine and applies damage immediately afterwards, so the
+        // whole clash has to fit inside clashSeconds. Previously this ran ~3.5s regardless
+        // while the caller waited 2s, leaving the blur up over the damage number.
+        yield return new WaitForSeconds(Mathf.Max(0.2f, clashSeconds));
 
         _blurryScreen.SetActive(false);
 
-        yield return new WaitForSeconds(1f);
-
         _player1TotalDisplay.gameObject.SetActive(false);
         _player2TotalDisplay.gameObject.SetActive(false);
+    }
+
+    /// <summary>
+    /// Impact shake on the board. <paramref name="severity"/> is 0..1 as a fraction of max HP.
+    /// The project had no impact feedback of any kind before this.
+    /// </summary>
+    public void ShakeBoard(float severity)
+    {
+        if (_board == null) return;
+
+        var strength = Mathf.Lerp(5f, 24f, Mathf.Clamp01(severity));
+
+        // Complete any in-flight shake first so repeated hits cannot accumulate drift.
+        _board.DOComplete();
+        _board.DOShakePosition(0.22f, strength, 18, 90f, false, true);
     }
 
     /// <summary>
@@ -279,7 +306,7 @@ public class UIController : MonoBehaviour
                 if (_card.HostedCard.IsAttackingCard())
                 {
                     GameObject _ps = Instantiate(_attackTallyPS, _card.transform.position, Quaternion.identity);
-                    _ps.GetComponent<TallyParticleEffect>().targetPosition = Vector2.zero; // _player1TotalDisplay.transform.position;
+                    _ps.GetComponent<TallyParticleEffect>().targetPosition = _player1TotalDisplay.transform.position;
                     var mainModule = _ps.GetComponent<ParticleSystem>().main;
                     Color startColor = Color.red;
                     startColor.a = 0.5f;
@@ -291,7 +318,7 @@ public class UIController : MonoBehaviour
                 if (_card.HostedCard.Type == PlayCardType.Defense)
                 {
                     GameObject _ps = Instantiate(_attackTallyPS, _card.transform.position, Quaternion.identity);
-                    _ps.GetComponent<TallyParticleEffect>().targetPosition = Vector2.zero; // _player2TotalDisplay.transform.position;
+                    _ps.GetComponent<TallyParticleEffect>().targetPosition = _player2TotalDisplay.transform.position;
                     var mainModule = _ps.GetComponent<ParticleSystem>().main;
                     Color startColor = Color.blue;
                     startColor.a = 0.5f;
@@ -307,7 +334,7 @@ public class UIController : MonoBehaviour
                 {
                     GameObject _ps = Instantiate(_attackTallyPS, _card.transform.position, Quaternion.identity);
                     //particle system moves toward the tally display for effect
-                    _ps.GetComponent<TallyParticleEffect>().targetPosition = Vector2.zero; // _player1TotalDisplay.transform.position;
+                    _ps.GetComponent<TallyParticleEffect>().targetPosition = _player1TotalDisplay.transform.position;
                     var mainModule = _ps.GetComponent<ParticleSystem>().main;
                     Color startColor = Color.blue;
                     startColor.a = 0.5f;
@@ -320,7 +347,7 @@ public class UIController : MonoBehaviour
                 {
                     GameObject _ps = Instantiate(_attackTallyPS, _card.transform.position, Quaternion.identity);
                     //particle system moves toward the tally display for effect
-                    _ps.GetComponent<TallyParticleEffect>().targetPosition = Vector2.zero; // _player2TotalDisplay.transform.position;
+                    _ps.GetComponent<TallyParticleEffect>().targetPosition = _player2TotalDisplay.transform.position;
                     var mainModule = _ps.GetComponent<ParticleSystem>().main;
                     Color startColor = Color.red;
                     startColor.a = 0.5f;
@@ -345,6 +372,10 @@ public class UIController : MonoBehaviour
     public void DisplayBattleResult(Player winner, bool currentPlayerWon)
     {
         Debug.Log("WINNER: " + winner.PlayerPepemon.DisplayName + " - " + (currentPlayerWon ? "Victory" : "Defeat"));
+
+        // The post-battle screen animates itself in and waits on its Animator, which cannot
+        // advance while a tutorial beat holds the game frozen.
+        if (BotTextTutorial.Instance != null) BotTextTutorial.Instance.ForceDismiss();
         PostScreenController.LoadPepemonDisplay(ulong.Parse(winner.PlayerPepemon.ID));
         PostScreenController.SetResult(currentPlayerWon);
         PostScreenController.Show();

--- a/Assets/Scripts/Data/BattleCard.cs
+++ b/Assets/Scripts/Data/BattleCard.cs
@@ -63,6 +63,20 @@ namespace Pepemon.Battle
         [LabelWidth(80)]
         public CardRarity Rarity;
 
+        /// <summary>
+        /// One-line playstyle hook shown on the starter-selection screen.
+        ///
+        /// This copy previously lived as a UnityEvent string argument inside StartScreen.unity,
+        /// where it could not be reviewed or edited without opening the scene.
+        /// </summary>
+        [BoxGroup("Flavour")]
+        [LabelWidth(80)]
+        public string Tagline;
+
+        [BoxGroup("Flavour")]
+        [LabelWidth(80), TextArea(2, 4)]
+        public string Description;
+
         [TitleGroup("Properties")] public int HealthPoints = 400;
         [TitleGroup("Properties")] public int Speed;
         [TitleGroup("Properties")] public int Intelligence;

--- a/Assets/Scripts/Editor/OnboardingDevTools.cs
+++ b/Assets/Scripts/Editor/OnboardingDevTools.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using Pepemon.Onboarding;
+using UnityEditor;
+using UnityEngine;
+
+/// <summary>
+/// Editor helpers for re-testing the first-battle flow.
+///
+/// Tutorial progress is monotonic and stored in PlayerPrefs, so without a reset the
+/// onboarding can only be observed once per machine - which is why regressions in it
+/// went unnoticed.
+/// </summary>
+public static class OnboardingDevTools
+{
+    [MenuItem("Pepemon/Reset Onboarding", priority = 100)]
+    public static void ResetOnboarding()
+    {
+        OnboardingState.Reset();
+        Debug.Log("[onboarding] Reset. The tutorial and starter-pack claim will run again on next play.");
+    }
+
+    [MenuItem("Pepemon/Log Onboarding State", priority = 101)]
+    public static void LogOnboardingState()
+    {
+        var seen = new List<int>();
+        foreach (var beat in TutorialScript.AllBeats)
+        {
+            if (OnboardingState.HasSeenBeat(beat.Id)) seen.Add(beat.Id);
+        }
+
+        Debug.Log($"[onboarding] beatsSeen=[{string.Join(",", seen)}] " +
+                  $"of {TutorialScript.BeatCount} " +
+                  $"hasClaimedStarterPack={OnboardingState.HasClaimedStarterPack}");
+    }
+
+    [MenuItem("Pepemon/Mark Starter Pack As Claimed", priority = 102)]
+    public static void MarkStarterPackClaimed()
+    {
+        OnboardingState.HasClaimedStarterPack = true;
+        Debug.Log("[onboarding] Starter pack marked claimed - the bot battle will now behave as a replay.");
+    }
+}

--- a/Assets/Scripts/Editor/OnboardingDevTools.cs.meta
+++ b/Assets/Scripts/Editor/OnboardingDevTools.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1803bdca877e44668c1279364aaede9e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Onboarding.meta
+++ b/Assets/Scripts/Onboarding.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ae18d4818f5b44e589b9a114c088d56e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Onboarding/OnboardingState.cs
+++ b/Assets/Scripts/Onboarding/OnboardingState.cs
@@ -29,6 +29,37 @@ namespace Pepemon.Onboarding
 
         public const string StarterPackKey = "GotStarterPack";
 
+        /// <summary>
+        /// The Pepemon and starter deck the player chose before their first battle.
+        ///
+        /// Persisted at selection time rather than read from Web3Controller at claim time:
+        /// the post-battle screen zeroes StarterPepemonID/StarterDeckID before loading the
+        /// menu scene, so by the time the claim runs the choice is already gone.
+        /// </summary>
+        public const string PendingPepemonKey = "PENDING_STARTER_PEPEMON";
+        public const string PendingDeckKey = "PENDING_STARTER_DECK";
+
+        public static int PendingStarterPepemonId
+        {
+            get => PlayerPrefs.GetInt(PendingPepemonKey, 0);
+            set
+            {
+                PlayerPrefs.SetInt(PendingPepemonKey, value);
+                PlayerPrefs.Save();
+            }
+        }
+
+        /// <summary>Starter deck id (10001 / 10002). 0 when the player has not chosen yet.</summary>
+        public static int PendingStarterDeckId
+        {
+            get => PlayerPrefs.GetInt(PendingDeckKey, 0);
+            set
+            {
+                PlayerPrefs.SetInt(PendingDeckKey, value);
+                PlayerPrefs.Save();
+            }
+        }
+
         public static int TutorialBeatsSeen
         {
             get => PlayerPrefs.GetInt(TutorialBeatsKey, 0);
@@ -70,6 +101,8 @@ namespace Pepemon.Onboarding
             PlayerPrefs.DeleteKey(TutorialBeatsKey);
             PlayerPrefs.DeleteKey(LegacyTutorialStateKey);
             PlayerPrefs.DeleteKey(StarterPackKey);
+            PlayerPrefs.DeleteKey(PendingPepemonKey);
+            PlayerPrefs.DeleteKey(PendingDeckKey);
             PlayerPrefs.Save();
         }
     }

--- a/Assets/Scripts/Onboarding/OnboardingState.cs
+++ b/Assets/Scripts/Onboarding/OnboardingState.cs
@@ -1,0 +1,76 @@
+using UnityEngine;
+
+namespace Pepemon.Onboarding
+{
+    /// <summary>
+    /// Single source of truth for first-battle onboarding progress.
+    ///
+    /// State is per-device (PlayerPrefs), not per-wallet: a new wallet in the same browser
+    /// keeps this progress, and the same wallet on another device starts over. Moving this
+    /// to a wallet-scoped record requires a backend and is out of scope here.
+    /// </summary>
+    public static class OnboardingState
+    {
+        /// <summary>
+        /// Bitmask of tutorial beats already seen, one bit per beat id.
+        ///
+        /// A bitmask rather than a high-water mark because beats are triggered by gameplay
+        /// events, not in a fixed order: the comeback beat fires on an HP threshold and could
+        /// otherwise arrive before the damage beat and suppress it permanently.
+        /// </summary>
+        public const string TutorialBeatsKey = "TUTORIAL_BEATS_SEEN";
+
+        /// <summary>
+        /// Progress counter written by the previous tutorial. Deliberately not migrated - the
+        /// script was rewritten, so the old value describes beats that no longer exist. Cleared
+        /// on reset so no stale key is left behind.
+        /// </summary>
+        public const string LegacyTutorialStateKey = "TUTORIAL_STATE_INDEX";
+
+        public const string StarterPackKey = "GotStarterPack";
+
+        public static int TutorialBeatsSeen
+        {
+            get => PlayerPrefs.GetInt(TutorialBeatsKey, 0);
+            set
+            {
+                PlayerPrefs.SetInt(TutorialBeatsKey, value);
+                PlayerPrefs.Save();
+            }
+        }
+
+        public static bool HasSeenBeat(int beatId)
+        {
+            if (beatId < 0 || beatId > 30) return false;
+            return (TutorialBeatsSeen & (1 << beatId)) != 0;
+        }
+
+        public static void MarkBeatSeen(int beatId)
+        {
+            if (beatId < 0 || beatId > 30) return;
+            TutorialBeatsSeen |= 1 << beatId;
+        }
+
+        /// <summary>
+        /// True only once the starter pack has actually been minted on-chain.
+        /// Never set this optimistically - a failed claim must stay claimable.
+        /// </summary>
+        public static bool HasClaimedStarterPack
+        {
+            get => PlayerPrefs.GetInt(StarterPackKey, 0) == 1;
+            set
+            {
+                PlayerPrefs.SetInt(StarterPackKey, value ? 1 : 0);
+                PlayerPrefs.Save();
+            }
+        }
+
+        public static void Reset()
+        {
+            PlayerPrefs.DeleteKey(TutorialBeatsKey);
+            PlayerPrefs.DeleteKey(LegacyTutorialStateKey);
+            PlayerPrefs.DeleteKey(StarterPackKey);
+            PlayerPrefs.Save();
+        }
+    }
+}

--- a/Assets/Scripts/Onboarding/OnboardingState.cs.meta
+++ b/Assets/Scripts/Onboarding/OnboardingState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b9540ac28bff4f869f59f7dd6a2b85bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Onboarding/StarterPackClaim.cs
+++ b/Assets/Scripts/Onboarding/StarterPackClaim.cs
@@ -1,0 +1,283 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
+using Pepemon.BattleRules;
+using Thirdweb;
+using UnityEngine;
+
+namespace Pepemon.Onboarding
+{
+    /// <summary>What the claim actually managed to do. Every field is independently meaningful.</summary>
+    public class StarterPackClaimResult
+    {
+        public bool CardsMinted;
+        public bool DeckCreated;
+        public ulong DeckId;
+        public bool BattleCardSet;
+        public int SupportCardsAdded;
+        public string Error;
+
+        /// <summary>
+        /// True when the player can take this deck straight into a battle. Anything less and
+        /// they are dropped into the deck builder, which is the drop-off we are trying to avoid.
+        /// </summary>
+        public bool DeckIsPlayable => DeckCreated && BattleCardSet && SupportCardsAdded > 0;
+
+        /// <summary>The irreversible part succeeded, so the claim must not be retried blindly.</summary>
+        public bool AssetsGranted => CardsMinted && DeckCreated;
+    }
+
+    /// <summary>
+    /// Mints the starter pack and assembles it into a ready-to-play deck.
+    ///
+    /// Minting alone is not a reward: it leaves the player holding loose cards and an empty
+    /// deck, facing a four-transaction deck builder before they can play again. This runs the
+    /// whole sequence so the player lands with something playable.
+    ///
+    /// The card ids granted by mintCards() are not knowable from the ABI, and the local
+    /// ScriptableObject ids are not guaranteed to match on-chain token ids. So rather than
+    /// assuming, this reads back actual balances and assembles from what the player provably
+    /// owns. If nothing matches, the cards and deck are still granted and the player is told
+    /// to finish in the deck builder - degraded, but never a lie.
+    /// </summary>
+    public static class StarterPackClaim
+    {
+        private const int DeckPropagationTimeoutMs = 20000;
+        private const int DeckPropagationPollMs = 1000;
+        private const int DefaultMaxSupportCards = 60;
+
+        public static async Task<StarterPackClaimResult> Run(
+            ulong pepemonId,
+            IReadOnlyList<ulong> desiredSupportCardIds,
+            Action<string> onStatus)
+        {
+            var result = new StarterPackClaimResult();
+            void Status(string m) => onStatus?.Invoke(m);
+
+            string address;
+            try
+            {
+                address = await ThirdwebManager.Instance.SDK.Wallet.GetAddress();
+            }
+            catch (Exception e)
+            {
+                result.Error = $"could not read wallet address: {e.Message}";
+                return result;
+            }
+
+            if (string.IsNullOrEmpty(address))
+            {
+                result.Error = "no wallet address";
+                return result;
+            }
+
+            ulong deckCountBefore;
+            try
+            {
+                deckCountBefore = await PepemonCardDeck.GetDeckCount(address);
+            }
+            catch (Exception e)
+            {
+                // Not fatal on its own, but without a baseline the new deck cannot be identified.
+                Debug.LogWarning($"[claim] could not read deck count: {e.Message}");
+                deckCountBefore = 0;
+            }
+
+            // ---- 1. Mint the cards -------------------------------------------------------
+            try
+            {
+                Status("Minting your cards...");
+                await PepemonCardDeck.MintCards();
+                result.CardsMinted = true;
+            }
+            catch (Exception e)
+            {
+                result.Error = $"mintCards failed: {e.Message}";
+                return result;
+            }
+
+            // ---- 2. Create the deck that will hold them ----------------------------------
+            try
+            {
+                Status("Creating your deck...");
+                await PepemonCardDeck.CreateDeck();
+                result.DeckCreated = true;
+            }
+            catch (Exception e)
+            {
+                result.Error = $"createDeck failed: {e.Message}";
+                return result;
+            }
+
+            // ---- 3. Find the new deck id -------------------------------------------------
+            // Polled rather than delayed by a fixed sleep: propagation time is not predictable
+            // and a too-short wait silently assembles nothing.
+            try
+            {
+                Status("Finding your new deck...");
+                result.DeckId = await WaitForNewDeck(address, deckCountBefore);
+            }
+            catch (Exception e)
+            {
+                result.Error = $"could not resolve new deck: {e.Message}";
+                return result;
+            }
+
+            if (result.DeckId == 0)
+            {
+                result.Error = "new deck did not appear in time";
+                return result;
+            }
+
+            // ---- 4. Let the deck contract move the player's cards -------------------------
+            try
+            {
+                var deckAddress = Web3Controller.instance.GetChainConfig().pepemonCardDeckAddress;
+                if (!await PepemonFactory.GetApprovalState(deckAddress))
+                {
+                    Status("Approving card transfers...");
+                    await PepemonFactory.SetApprovalState(true, deckAddress);
+                }
+            }
+            catch (Exception e)
+            {
+                result.Error = $"approval failed: {e.Message}";
+                return result;
+            }
+
+            // ---- 5. Assemble from what the player provably owns ---------------------------
+            var candidateIds = new List<ulong> { pepemonId };
+            foreach (var id in desiredSupportCardIds)
+            {
+                if (!candidateIds.Contains(id)) candidateIds.Add(id);
+            }
+
+            Dictionary<ulong, int> owned;
+            try
+            {
+                Status("Checking your new cards...");
+                owned = await PepemonFactory.GetOwnedCards(address, candidateIds);
+            }
+            catch (Exception e)
+            {
+                result.Error = $"could not read owned cards: {e.Message}";
+                return result;
+            }
+
+            if (owned == null || owned.Count == 0)
+            {
+                result.Error = "minted cards did not match the starter list";
+                return result;
+            }
+
+            if (owned.ContainsKey(pepemonId))
+            {
+                try
+                {
+                    Status("Adding your Pepemon...");
+                    await PepemonCardDeck.SetBattleCard(result.DeckId, pepemonId);
+                    result.BattleCardSet = true;
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning($"[claim] setBattleCard failed: {e.Message}");
+                }
+            }
+            else
+            {
+                Debug.LogWarning($"[claim] player does not own Pepemon {pepemonId}; skipping battle card.");
+            }
+
+            var requests = BuildSupportCardRequests(desiredSupportCardIds, owned, await ReadMaxSupportCards());
+            if (requests.Count > 0)
+            {
+                try
+                {
+                    Status("Building your deck...");
+                    await PepemonCardDeck.AddSupportCards(result.DeckId, requests.ToArray());
+
+                    foreach (var r in requests) result.SupportCardsAdded += (int)r.Amount;
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning($"[claim] addSupportCards failed: {e.Message}");
+                }
+            }
+
+            return result;
+        }
+
+        private static async Task<int> ReadMaxSupportCards()
+        {
+            try
+            {
+                var max = await PepemonCardDeck.GetMaxSupportCards();
+                return max > 0 ? max : DefaultMaxSupportCards;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[claim] could not read MAX_SUPPORT_CARDS, using {DefaultMaxSupportCards}: {e.Message}");
+                return DefaultMaxSupportCards;
+            }
+        }
+
+        /// <summary>
+        /// Turns the desired starter list into transfer requests. Selection rules live in
+        /// <see cref="StarterDeckAssembly"/> so they can be tested; this only adapts the result
+        /// to the contract's request type.
+        /// </summary>
+        internal static List<PepemonCardDeck.SupportCardRequest> BuildSupportCardRequests(
+            IReadOnlyList<ulong> desiredIds,
+            IReadOnlyDictionary<ulong, int> owned,
+            int maxSupportCards)
+        {
+            var selection = StarterDeckAssembly.SelectSupportCards(
+                desiredIds,
+                owned,
+                maxSupportCards > 0 ? maxSupportCards : DefaultMaxSupportCards);
+
+            var requests = new List<PepemonCardDeck.SupportCardRequest>(selection.Count);
+            foreach (var kvp in selection)
+            {
+                requests.Add(new PepemonCardDeck.SupportCardRequest
+                {
+                    SupportCardId = kvp.Key,
+                    Amount = kvp.Value
+                });
+            }
+
+            return requests;
+        }
+
+        private static async Task<ulong> WaitForNewDeck(string address, ulong deckCountBefore)
+        {
+            var waited = 0;
+            while (waited < DeckPropagationTimeoutMs)
+            {
+                // Realtime, not scaled game time: this waits on the chain, not on the game, and
+                // a stray timeScale of 0 would otherwise hang the poll forever.
+                await UniTask.Delay(DeckPropagationPollMs, DelayType.Realtime);
+                waited += DeckPropagationPollMs;
+
+                ulong count;
+                try
+                {
+                    count = await PepemonCardDeck.GetDeckCount(address);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning($"[claim] deck count poll failed: {e.Message}");
+                    continue;
+                }
+
+                if (count <= deckCountBefore) continue;
+
+                // The newest deck is the last entry in the player's list.
+                return await PepemonCardDeck.GetPlayerDeckAt(address, count - 1);
+            }
+
+            return 0;
+        }
+    }
+}

--- a/Assets/Scripts/Onboarding/StarterPackClaim.cs.meta
+++ b/Assets/Scripts/Onboarding/StarterPackClaim.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b125d63e2fbe47bd92689a4b0b398639
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Onboarding/TutorialScript.cs
+++ b/Assets/Scripts/Onboarding/TutorialScript.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+
+namespace Pepemon.Onboarding
+{
+    /// <summary>How a tutorial beat interrupts the battle.</summary>
+    public enum TutorialBeatMode
+    {
+        /// <summary>Freezes the battle and waits for the player to advance. Use sparingly.</summary>
+        Modal,
+
+        /// <summary>Shown alongside the battle and dismisses itself. Never blocks.</summary>
+        Toast
+    }
+
+    public class TutorialBeat
+    {
+        public int Id;
+        public string Text;
+        public TutorialBeatMode Mode;
+
+        /// <summary>Seconds a Toast stays up. Ignored for Modal beats.</summary>
+        public float ToastSeconds;
+    }
+
+    /// <summary>
+    /// The authored first-battle script and its cast.
+    ///
+    /// Lives in code rather than scene YAML so the copy is reviewable in a diff. The
+    /// previous version was serialized into SandboxNew.unity, which is why it drifted
+    /// out of sync with the battle rules it described.
+    ///
+    /// Every mechanical claim below is checked against GameController:
+    ///  - win condition is HP reaching 0 (there is no round cap - LoopGame runs until
+    ///    someone dies, so the old "each battle lasts 5 rounds" line was simply wrong)
+    ///  - decks reshuffle on every 5th round (GameController._roundNumber % 5 == 0)
+    ///  - cards drawn per round equals INT (Player.DrawNewHand)
+    ///  - attack order is highest SPD first (GameController.ResolveAttacker)
+    ///  - damage is attack minus defense, floored at 1 (GameController dmg calculation)
+    /// </summary>
+    public static class TutorialScript
+    {
+        /// <summary>The rival trainer's handle. The bot always fields a Mandraky.</summary>
+        public const string RivalName = "PAPERHANDS";
+
+        public const string RivalTaunt = "Nice deck. I'll be taking that starter pack.";
+        public const string RivalDefeatLine = "Rugged by a rookie. GG.";
+
+        public const string WinHeadline = "You beat " + RivalName + "!";
+        public const string WinSubline = "Claim your starter pack";
+        public const string LoseSubline = "Run it back";
+
+        public const int BeatIntro = 1;
+        public const int BeatDraw = 2;
+        public const int BeatDamage = 3;
+        public const int BeatComeback = 4;
+
+        // There is deliberately no in-battle victory beat. The post-battle screen appears
+        // immediately after the killing blow and already carries the payoff copy, and a modal
+        // beat at that moment would hold the game at timeScale 0 while that screen tries to
+        // play its show animation - which would stall it forever.
+
+        /// <summary>Fraction of max HP below which the comeback beat fires.</summary>
+        public const float ComebackHpThreshold = 0.4f;
+
+        private static readonly Dictionary<int, TutorialBeat> Beats = new Dictionary<int, TutorialBeat>
+        {
+            [BeatIntro] = new TutorialBeat
+            {
+                Id = BeatIntro,
+                Mode = TutorialBeatMode.Modal,
+                Text = RivalName + " wants your starter pack.\n" +
+                       "Drop their Mandraky to 0 HP and it's yours, Pepetrainer."
+            },
+            [BeatDraw] = new TutorialBeat
+            {
+                Id = BeatDraw,
+                Mode = TutorialBeatMode.Toast,
+                ToastSeconds = 4.5f,
+                Text = "Your INT sets how many cards you draw each round.\n" +
+                       "Highest SPD swings first."
+            },
+            [BeatDamage] = new TutorialBeat
+            {
+                Id = BeatDamage,
+                Mode = TutorialBeatMode.Toast,
+                ToastSeconds = 5f,
+                Text = "Damage = your ATK plus offense cards, minus their defense.\n" +
+                       "At least 1 always gets through."
+            },
+            [BeatComeback] = new TutorialBeat
+            {
+                Id = BeatComeback,
+                Mode = TutorialBeatMode.Toast,
+                ToastSeconds = 4f,
+                Text = RivalName + " is connecting.\n" +
+                       "Every Pepetrainer's first comeback starts about here."
+            }
+        };
+
+        public static int BeatCount => Beats.Count;
+
+        public static bool TryGetBeat(int id, out TutorialBeat beat) => Beats.TryGetValue(id, out beat);
+
+        public static IEnumerable<TutorialBeat> AllBeats => Beats.Values;
+    }
+}

--- a/Assets/Scripts/Onboarding/TutorialScript.cs.meta
+++ b/Assets/Scripts/Onboarding/TutorialScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f23277cca8b2435ea4e0c88328f43228
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SFX/SFXManager.cs
+++ b/Assets/Scripts/SFX/SFXManager.cs
@@ -11,35 +11,49 @@ public class SFXManager : MonoBehaviour
     [SerializeField] private AudioClip hitSFX;
     [SerializeField] private AudioClip slideSFX;
 
+    [Header("Battle emphasis")]
+    // Optional. Each falls back to an existing clip when unassigned, so the hooks are usable
+    // before new audio exists rather than silently doing nothing.
+    [SerializeField] private AudioClip bigHitSFX;
+    [SerializeField] private AudioClip lowHealthSFX;
+    [SerializeField] private AudioClip roundStartSFX;
+
     public static SFXManager Instance;
 
-    private void Start()
+    // Awake, not Start: CardController and GameController both call SFXManager.Instance from
+    // their own Start/first frame, which previously raced this assignment.
+    private void Awake()
     {
         Instance = this;
     }
 
-    public void BtnSFX()
+    private void OnDestroy()
     {
-        PlaySFX(btnSFX, 1f);
+        if (Instance == this) Instance = null;
     }
-    
-    public void DealSFX()
-    {
-        PlaySFX(dealSFX, 1f);
-    }
-    
-    public void HitSFX()
-    {
-        PlaySFX(hitSFX, 1f);
-    }
-    
-    public void SlideSFX()
-    {
-        PlaySFX(slideSFX, 0.05f);
-    }
+
+    public void BtnSFX() => PlaySFX(btnSFX, 1f);
+
+    public void DealSFX() => PlaySFX(dealSFX, 1f);
+
+    public void HitSFX() => PlaySFX(hitSFX, 1f);
+
+    public void SlideSFX() => PlaySFX(slideSFX, 0.05f);
+
+    /// <summary>Heavier hit. Falls back to the normal hit clip, louder.</summary>
+    public void BigHitSFX() => PlaySFX(bigHitSFX != null ? bigHitSFX : hitSFX, 1f);
+
+    /// <summary>Played once when a combatant drops into the danger zone.</summary>
+    public void LowHealthSFX() => PlaySFX(lowHealthSFX != null ? lowHealthSFX : hitSFX, 0.6f);
+
+    public void RoundStartSFX() => PlaySFX(roundStartSFX != null ? roundStartSFX : dealSFX, 0.7f);
 
     private void PlaySFX(AudioClip clip, float volume = 0.5f)
     {
-        Instantiate(sfxPlayer.gameObject, transform.position, Quaternion.identity).GetComponent<SFXPlayer>().PlaySFXWithVolume(clip, volume);
+        if (clip == null || sfxPlayer == null) return;
+
+        Instantiate(sfxPlayer.gameObject, transform.position, Quaternion.identity)
+            .GetComponent<SFXPlayer>()
+            .PlaySFXWithVolume(clip, volume);
     }
 }

--- a/Assets/Scripts/Telemetry.meta
+++ b/Assets/Scripts/Telemetry.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8322e12562fd46bca125f058e670551e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Telemetry/Funnel.cs
+++ b/Assets/Scripts/Telemetry/Funnel.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace Pepemon.Telemetry
+{
+    /// <summary>
+    /// Destination for tracked events. Swap via <see cref="Funnel.SetBackend"/> once a
+    /// real provider is chosen; nothing at the call sites changes.
+    /// </summary>
+    public interface ITelemetryBackend
+    {
+        void Track(string eventName, IReadOnlyDictionary<string, object> properties);
+    }
+
+    /// <summary>Default backend. Writes to the Unity console so the funnel is visible in dev builds.</summary>
+    public class DebugLogTelemetryBackend : ITelemetryBackend
+    {
+        public void Track(string eventName, IReadOnlyDictionary<string, object> properties)
+        {
+            if (properties == null || properties.Count == 0)
+            {
+                Debug.Log($"[telemetry] {eventName}");
+                return;
+            }
+
+            var sb = new StringBuilder();
+            sb.Append("[telemetry] ").Append(eventName).Append(" {");
+            var first = true;
+            foreach (var kvp in properties)
+            {
+                if (!first) sb.Append(", ");
+                sb.Append(kvp.Key).Append('=').Append(kvp.Value ?? "null");
+                first = false;
+            }
+            sb.Append('}');
+            Debug.Log(sb.ToString());
+        }
+    }
+
+    /// <summary>Discards everything. Use to disable telemetry without touching call sites.</summary>
+    public class NullTelemetryBackend : ITelemetryBackend
+    {
+        public void Track(string eventName, IReadOnlyDictionary<string, object> properties) { }
+    }
+
+    /// <summary>
+    /// Thin funnel-instrumentation facade.
+    ///
+    /// Named Funnel rather than Analytics or Telemetry so the type can never collide with the
+    /// UnityEngine.Analytics namespace, nor with its own Pepemon.Telemetry namespace - a class
+    /// sharing its namespace's name becomes ambiguous the moment anyone adds `using Pepemon;`.
+    ///
+    /// Tracking must never affect gameplay, so every call is swallowed on failure.
+    /// </summary>
+    public static class Funnel
+    {
+        #region Event names
+        public const string AppLoaded = "app_loaded";
+        public const string StartPressed = "start_pressed";
+        public const string PepemonSelected = "pepemon_selected";
+        public const string FirstBattleStarted = "first_battle_started";
+        public const string TutorialBeatShown = "tutorial_beat_shown";
+        public const string TutorialBeatDismissed = "tutorial_beat_dismissed";
+        public const string FirstBattleEnded = "first_battle_ended";
+        public const string ClaimClicked = "claim_clicked";
+        public const string WalletConnectRequested = "wallet_connect_requested";
+        public const string WalletConnectResult = "wallet_connect_result";
+        public const string MintResult = "mint_result";
+        public const string ReturnedToMenu = "returned_to_menu";
+        #endregion
+
+        private static ITelemetryBackend _backend = new DebugLogTelemetryBackend();
+
+        public static void SetBackend(ITelemetryBackend backend)
+        {
+            _backend = backend ?? new NullTelemetryBackend();
+        }
+
+        public static void Track(string eventName)
+        {
+            Track(eventName, null);
+        }
+
+        public static void Track(string eventName, IReadOnlyDictionary<string, object> properties)
+        {
+            if (string.IsNullOrEmpty(eventName)) return;
+
+            try
+            {
+                _backend?.Track(eventName, properties);
+            }
+            catch (Exception e)
+            {
+                // Never let instrumentation break the game.
+                Debug.LogWarning($"[telemetry] dropped '{eventName}': {e.Message}");
+            }
+        }
+
+        /// <summary>Convenience for the common one-to-three property case.</summary>
+        public static void Track(string eventName, string key, object value)
+        {
+            Track(eventName, new Dictionary<string, object> { [key] = value });
+        }
+
+        public static void Track(string eventName, string k1, object v1, string k2, object v2)
+        {
+            Track(eventName, new Dictionary<string, object> { [k1] = v1, [k2] = v2 });
+        }
+
+        public static void Track(string eventName, string k1, object v1, string k2, object v2, string k3, object v3)
+        {
+            Track(eventName, new Dictionary<string, object> { [k1] = v1, [k2] = v2, [k3] = v3 });
+        }
+    }
+}

--- a/Assets/Scripts/Telemetry/Funnel.cs.meta
+++ b/Assets/Scripts/Telemetry/Funnel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 877ca29025894c17abceb48fb8f76192
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/HealthSystem.cs
+++ b/Assets/Scripts/UI/HealthSystem.cs
@@ -29,11 +29,15 @@ public class HealthSystem : MonoBehaviour
         {
             _health = 0;
             IsDead = true;
-            return;
+        }
+        else
+        {
+            _health -= value;
         }
 
-        _health -= value;
-
+        // Restart the drain in both cases. The lethal branch used to return before this, so
+        // the killing blow - the single most dramatic moment in the battle - snapped the bar
+        // to empty instead of animating.
         lerpTimer = 0f;
     }
 
@@ -44,6 +48,9 @@ public class HealthSystem : MonoBehaviour
 
     private void UpdateHealthUI()
     {
+        if (_healthBackImage == null || _healthFrontImage == null) return;
+        if (starterHealth <= 0f) return;
+
         float fillB = _healthBackImage.fillAmount;
         float hFraction = _health / starterHealth;
 

--- a/Assets/Scripts/UI/VersusScreenDisplay.cs
+++ b/Assets/Scripts/UI/VersusScreenDisplay.cs
@@ -15,7 +15,24 @@ public class VersusScreenDisplay : MonoBehaviour
     [SerializeField] private TMPro.TMP_Text nameRed;
     [SerializeField] private TMPro.TMP_Text nameBlue;
 
+    /// <summary>Optional. Gives the opponent a voice instead of 3 seconds of dead air.</summary>
+    [SerializeField] private TMPro.TMP_Text tauntLabel;
+
+    [SerializeField] private float holdSeconds = 2.5f;
+    [SerializeField] private float fadeSeconds = 0.6f;
+
+    /// <summary>Ignore input briefly so a carried-over tap cannot skip the screen instantly.</summary>
+    private const float SkipLockSeconds = 0.4f;
+
+    private bool isShowing;
+    private float skipUnlockedAtUnscaled;
+
     public void SetVersusScreen(Sprite red, Sprite blue, Sprite bgB, Sprite bgR, string blueN, string redN)
+    {
+        SetVersusScreen(red, blue, bgB, bgR, blueN, redN, null);
+    }
+
+    public void SetVersusScreen(Sprite red, Sprite blue, Sprite bgB, Sprite bgR, string blueN, string redN, string taunt)
     {
         imgRed.sprite = red;
         imgBlue.sprite = blue;
@@ -25,13 +42,51 @@ public class VersusScreenDisplay : MonoBehaviour
             bgBlue.sprite = bgB;
         nameRed.text = redN;
         nameBlue.text = blueN;
+
+        if (tauntLabel != null)
+        {
+            tauntLabel.text = taunt ?? string.Empty;
+            tauntLabel.gameObject.SetActive(!string.IsNullOrEmpty(taunt));
+        }
+
         StartCoroutine(Transition());
     }
 
     private IEnumerator Transition()
     {
-        yield return new WaitForSeconds(3.25f);
+        isShowing = true;
+        skipUnlockedAtUnscaled = Time.unscaledTime + SkipLockSeconds;
 
-        canvasGroup.DOFade(0f, 1f);
+        var hideAt = Time.unscaledTime + Mathf.Max(0.5f, holdSeconds);
+
+        // Skippable. This was a fixed 3.25s wait with no way past it, which is a long time to
+        // stare at a static screen on a repeat run.
+        while (Time.unscaledTime < hideAt && !WasSkipRequested())
+        {
+            yield return null;
+        }
+
+        isShowing = false;
+        canvasGroup.DOFade(0f, fadeSeconds);
+    }
+
+    private bool WasSkipRequested()
+    {
+        if (!isShowing) return false;
+        if (Time.unscaledTime < skipUnlockedAtUnscaled) return false;
+
+        if (Input.GetKeyDown(KeyCode.Space) ||
+            Input.GetKeyDown(KeyCode.Return) ||
+            Input.GetMouseButtonDown(0))
+        {
+            return true;
+        }
+
+        for (int i = 0; i < Input.touchCount; i++)
+        {
+            if (Input.GetTouch(i).phase == TouchPhase.Began) return true;
+        }
+
+        return false;
     }
 }

--- a/Assets/Tests.meta
+++ b/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 35f96f9bac4f46e28af3a410857f6be0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode.meta
+++ b/Assets/Tests/EditMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a932f6becb4942d5976e7d1987f1f46c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/Pepemon.BattleRules.Tests.asmdef
+++ b/Assets/Tests/EditMode/Pepemon.BattleRules.Tests.asmdef
@@ -1,0 +1,24 @@
+{
+    "name": "Pepemon.BattleRules.Tests",
+    "rootNamespace": "",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "Pepemon.BattleRules"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Tests/EditMode/Pepemon.BattleRules.Tests.asmdef.meta
+++ b/Assets/Tests/EditMode/Pepemon.BattleRules.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: da9e474f2c2845c98e167cb6e8970e9c
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/StarterDeckAssemblyTests.cs
+++ b/Assets/Tests/EditMode/StarterDeckAssemblyTests.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Pepemon.BattleRules;
+
+/// <summary>
+/// The claim assembles a deck from cards a faucet grants, and the granted token ids are not
+/// knowable ahead of time. These cover the cases where the starter list and reality disagree -
+/// getting any of them wrong either reverts the assembly transaction or hands the player a
+/// deck they cannot play.
+/// </summary>
+public class StarterDeckAssemblyTests
+{
+    private static Dictionary<ulong, int> Owned(params (ulong id, int amount)[] entries)
+    {
+        var d = new Dictionary<ulong, int>();
+        foreach (var (id, amount) in entries) d[id] = amount;
+        return d;
+    }
+
+    [Test]
+    public void SelectsOnlyCardsThePlayerActuallyOwns()
+    {
+        var selection = StarterDeckAssembly.SelectSupportCards(
+            new List<ulong> { 10, 20, 30 },
+            Owned((10, 1), (30, 1)),
+            maxSupportCards: 60);
+
+        Assert.AreEqual(2, selection.Count);
+        Assert.IsTrue(selection.ContainsKey(10));
+        Assert.IsFalse(selection.ContainsKey(20), "card 20 is not owned and must be skipped");
+        Assert.IsTrue(selection.ContainsKey(30));
+    }
+
+    [Test]
+    public void CountsDuplicatesInTheStarterList()
+    {
+        var selection = StarterDeckAssembly.SelectSupportCards(
+            new List<ulong> { 10, 10, 10 },
+            Owned((10, 5)),
+            maxSupportCards: 60);
+
+        Assert.AreEqual(3, selection[10]);
+    }
+
+    [Test]
+    public void NeverAsksForMoreCopiesThanAreOwned()
+    {
+        var selection = StarterDeckAssembly.SelectSupportCards(
+            new List<ulong> { 10, 10, 10 },
+            Owned((10, 2)),
+            maxSupportCards: 60);
+
+        Assert.AreEqual(2, selection[10], "asking for 3 while owning 2 would revert the transaction");
+    }
+
+    [Test]
+    public void RespectsTheContractCap()
+    {
+        var desired = new List<ulong>();
+        for (ulong i = 0; i < 20; i++) desired.Add(i);
+
+        var owned = new Dictionary<ulong, int>();
+        for (ulong i = 0; i < 20; i++) owned[i] = 1;
+
+        var selection = StarterDeckAssembly.SelectSupportCards(desired, owned, maxSupportCards: 5);
+
+        Assert.AreEqual(5, StarterDeckAssembly.TotalCards(selection));
+    }
+
+    [Test]
+    public void CapTruncatesFromTheEndSoTheDeckKeepsItsCore()
+    {
+        var selection = StarterDeckAssembly.SelectSupportCards(
+            new List<ulong> { 1, 2, 3, 4 },
+            Owned((1, 1), (2, 1), (3, 1), (4, 1)),
+            maxSupportCards: 2);
+
+        Assert.IsTrue(selection.ContainsKey(1));
+        Assert.IsTrue(selection.ContainsKey(2));
+        Assert.IsFalse(selection.ContainsKey(3));
+        Assert.IsFalse(selection.ContainsKey(4));
+    }
+
+    [Test]
+    public void PartialCopiesFitIntoARemainingBudget()
+    {
+        var selection = StarterDeckAssembly.SelectSupportCards(
+            new List<ulong> { 1, 2, 2, 2 },
+            Owned((1, 1), (2, 3)),
+            maxSupportCards: 3);
+
+        Assert.AreEqual(1, selection[1]);
+        Assert.AreEqual(2, selection[2], "only 2 of the budget remained after card 1");
+        Assert.AreEqual(3, StarterDeckAssembly.TotalCards(selection));
+    }
+
+    [Test]
+    public void OwningNothingProducesNoTransaction()
+    {
+        var selection = StarterDeckAssembly.SelectSupportCards(
+            new List<ulong> { 10, 20 },
+            Owned(),
+            maxSupportCards: 60);
+
+        Assert.IsEmpty(selection, "an empty selection must not be sent as an addSupportCards call");
+    }
+
+    [Test]
+    public void HandlesNullAndZeroCapWithoutThrowing()
+    {
+        Assert.IsEmpty(StarterDeckAssembly.SelectSupportCards(null, Owned((1, 1)), 60));
+        Assert.IsEmpty(StarterDeckAssembly.SelectSupportCards(new List<ulong> { 1 }, null, 60));
+        Assert.IsEmpty(StarterDeckAssembly.SelectSupportCards(new List<ulong> { 1 }, Owned((1, 1)), 0));
+    }
+
+    [Test]
+    public void TotalCards_HandlesNull()
+    {
+        Assert.AreEqual(0, StarterDeckAssembly.TotalCards(null));
+    }
+}

--- a/Assets/Tests/EditMode/StarterDeckAssemblyTests.cs.meta
+++ b/Assets/Tests/EditMode/StarterDeckAssemblyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 98f74954d9b2408d9b5d6a7518ac6530
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/TutorialWinGuaranteeTests.cs
+++ b/Assets/Tests/EditMode/TutorialWinGuaranteeTests.cs
@@ -1,0 +1,97 @@
+using NUnit.Framework;
+using Pepemon.BattleRules;
+
+/// <summary>
+/// The first battle is advertised as unloseable. These tests are the only thing that actually
+/// holds that promise - before this, the "guaranteed" win was a stat bias plus a random seed
+/// and a new player could and did lose their first fight.
+/// </summary>
+public class TutorialWinGuaranteeTests
+{
+    [Test]
+    public void ResolveDamage_AlwaysDealsAtLeastOne()
+    {
+        Assert.AreEqual(1, TutorialWinGuarantee.ResolveDamage(0, 100));
+        Assert.AreEqual(1, TutorialWinGuarantee.ResolveDamage(5, 5));
+        Assert.AreEqual(1, TutorialWinGuarantee.ResolveDamage(3, 18));
+    }
+
+    [Test]
+    public void ResolveDamage_SubtractsDefenceWhenAttackWins()
+    {
+        Assert.AreEqual(9, TutorialWinGuarantee.ResolveDamage(19, 10));
+        Assert.AreEqual(13, TutorialWinGuarantee.ResolveDamage(19, 6));
+    }
+
+    [Test]
+    public void ClampLethalDamage_LeavesNonLethalHitsAlone()
+    {
+        Assert.AreEqual(6, TutorialWinGuarantee.ClampLethalDamage(30, 6, guaranteeSurvival: true));
+    }
+
+    [Test]
+    public void ClampLethalDamage_LeavesPlayerOnOneHp()
+    {
+        var dmg = TutorialWinGuarantee.ClampLethalDamage(4, 99, guaranteeSurvival: true);
+
+        Assert.AreEqual(3, dmg, "damage should be reduced to leave exactly 1 HP");
+        Assert.AreEqual(1, 4 - dmg);
+    }
+
+    [Test]
+    public void ClampLethalDamage_AtOneHpBlocksEverything()
+    {
+        Assert.AreEqual(0, TutorialWinGuarantee.ClampLethalDamage(1, 50, guaranteeSurvival: true));
+    }
+
+    [Test]
+    public void ClampLethalDamage_DoesNothingWhenProtectionIsOff()
+    {
+        // Regular bot battles and PvP must stay losable.
+        Assert.AreEqual(99, TutorialWinGuarantee.ClampLethalDamage(4, 99, guaranteeSurvival: false));
+    }
+
+    [Test]
+    public void ProtectedPlayerSurvivesAnUnlimitedBeating()
+    {
+        var hp = 20;
+
+        for (var i = 0; i < 500; i++)
+        {
+            var dmg = TutorialWinGuarantee.ClampLethalDamage(hp, 999, guaranteeSurvival: true);
+            hp -= dmg;
+
+            Assert.Greater(hp, 0, $"protected player died on exchange {i}");
+        }
+    }
+
+    /// <summary>
+    /// The guarantee is only meaningful if the battle also ends. Minimum damage of 1 means the
+    /// bot's HP strictly decreases every exchange, so the player's win is reached in bounded time.
+    /// </summary>
+    [Test]
+    public void BotAlwaysDiesInBoundedRounds()
+    {
+        var botHp = 20;
+        var exchanges = 0;
+
+        while (botHp > 0)
+        {
+            // Worst case for the player: the bot out-defends every single attack.
+            botHp -= TutorialWinGuarantee.ResolveDamage(1, 999);
+            exchanges++;
+
+            Assert.Less(exchanges, 1000, "battle failed to terminate");
+        }
+
+        Assert.AreEqual(20, exchanges, "worst case is exactly one damage per exchange");
+    }
+
+    [Test]
+    public void IsLethal_DetectsTheKillingBlow()
+    {
+        Assert.IsTrue(TutorialWinGuarantee.IsLethal(5, 5));
+        Assert.IsTrue(TutorialWinGuarantee.IsLethal(5, 9));
+        Assert.IsFalse(TutorialWinGuarantee.IsLethal(5, 4));
+    }
+}

--- a/Assets/Tests/EditMode/TutorialWinGuaranteeTests.cs.meta
+++ b/Assets/Tests/EditMode/TutorialWinGuaranteeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43bd9f6e9d5f43b8aa2651a78f65bdde
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The first battle is the whole top of funnel, and two of its three design premises were false in code.

Blockers fixed:
- The tutorial could only be advanced with the spacebar while holding the game at timeScale 0, so touch players were permanently stuck and desktop WebGL players were stuck whenever the canvas lost keyboard focus. Any of key/mouse/touch now advances, and the quit button is never hidden.
- "CLAIM YOUR STARTER PACK" granted nothing: ClaimStarterDeck() logged an error and set the claimed flag anyway. It now mints for real via the existing permissionless faucet (mintCards + createDeck) and only records the claim once both transactions confirm, so a failure stays retryable.
- The first battle was not a guaranteed win. The fixed seed was overwritten by System.Random on every run, leaving only a stat bias, so a new player could lose. The seed is now fixed and lethal damage is clamped while the starter pack is unclaimed.

Teaching:
- Card names were commented out and disabled in the prefab, so the tutorial explained support cards the player could not read. Re-enabled, with the full effect text in the preview.
- Rewrote the script as four beats fired at the moment each thing happens, one modal and three non-blocking toasts, and removed the "each battle lasts 5 rounds" claim, which contradicts both the code and the docs.
- Starter copy moved from scene-embedded UnityEvent arguments onto the Pepemon ScriptableObjects.

Feel:
- Named rival (PAPERHANDS) with a VS-screen taunt; VS screen is skippable.
- Equalised player 1 and player 2 turn length (was 1.5s vs 3s), extracted all pacing into BattlePacing, added hold-to-fast-forward from round 2.
- Fixed: lethal hits snapping the HP bar instead of draining, tally particles flying to world origin, cards staying permanently grey, and a damage number that faded in over 1.5s but was only held for 1s.

Infrastructure:
- TimeControl arbitrates Time.timeScale; three systems previously wrote it directly, so closing a card preview unfroze the battle behind a modal beat and leaving the scene mid-freeze stranded the menu at timeScale 0.
- OnboardingState centralises progress; beats are tracked per-beat rather than by high-water mark so an HP-triggered beat cannot suppress an earlier one.
- Funnel telemetry facade with a swappable backend covering connect, selection, every tutorial beat, battle outcome and mint result.
- TutorialWinGuarantee extracted as pure logic with EditMode tests, including proof the battle still terminates under the clamp.
- Pepemon > Reset Onboarding editor tool; progress is monotonic and device-local, so the tutorial was previously observable only once per machine.