### PR TITLE
fix(deck): make the deck editor refresh and fail visibly

### DIFF
--- a/Assets/Scripts/Controllers/DeckController.cs
+++ b/Assets/Scripts/Controllers/DeckController.cs
@@ -82,11 +82,21 @@ public class DeckController : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// Keeps an unplayable deck visible in the selection list instead of removing it.
+    ///
+    /// This used to do gameObject.SetActive(!notValidDeck), which deleted invalid decks from
+    /// the picker. A player whose decks were all incomplete - or whose valid decks were
+    /// misclassified by a metadata cache miss - got an empty screen with nothing to click and
+    /// no explanation of why. The deck now stays listed with its error message showing; only
+    /// the Select button is withheld.
+    /// </summary>
     private void UpdateNotValidDeckIsNotShowWhenSelecting()
     {
-        if(!_editButton.gameObject.activeSelf)
+        if (!_editButton.gameObject.activeSelf)
         {
-            gameObject.SetActive(!notValidDeck); //hide the deck on selection if it is not valid
+            gameObject.SetActive(true);
+            _selectButton.gameObject.SetActive(!notValidDeck);
         }
     }
 
@@ -154,11 +164,21 @@ public class DeckController : MonoBehaviour
             _supportCardCount.text = starterDeck.Count.ToString();
         }
 
-        notValidDeck = metadata?.name == null || supportCardCount == 0;
+        // Validity is decided purely by what the deck contains on-chain.
+        //
+        // This previously keyed off metadata?.name, which comes from the card metadata cache.
+        // A cache miss - which happens routinely for a freshly minted card, or any time the
+        // cache has not finished loading - made a deck that was perfectly valid on-chain look
+        // invalid, and invalid decks were then removed from the selection list entirely. The
+        // result was an empty deck picker with nothing to select and no way to play.
+        bool hasBattleCard = battleCard != 0;
+        bool hasSupportCards = supportCardCount > 0;
+
+        notValidDeck = !hasBattleCard || !hasSupportCards;
 
         if (!isStarterDeck)
         {
-            if (metadata?.name == null)
+            if (!hasBattleCard)
             {
                 _errorDisplay.SetActive(true);
                 _errorText.text = "Pepemon card missing";
@@ -166,7 +186,7 @@ public class DeckController : MonoBehaviour
                 UpdateNotValidDeckIsNotShowWhenSelecting();
                 return true;
             }
-            if (supportCardCount == 0)
+            if (!hasSupportCards)
             {
                 _errorDisplay.SetActive(true);
                 _errorText.text = "Support cards missing";

--- a/Assets/Scripts/Controllers/MainMenuController.cs
+++ b/Assets/Scripts/Controllers/MainMenuController.cs
@@ -175,7 +175,20 @@ public class MainMenuController : MonoBehaviour
                 Debug.LogWarning("[claim] BattlePrepController not found; deck will be created without support cards.");
             }
 
-            var result = await StarterPackClaim.Run((ulong)pepemonId, supportCardIds, SetClaimStatus);
+            // Runtime-built overlay: the serialized status label was never wired, so all of
+            // this previously reached the console only and the player signed five wallet
+            // prompts with nothing on screen telling them what any of them were for.
+            var overlay = ClaimProgressOverlay.Instance;
+            overlay.Show("Claiming your starter pack");
+
+            var result = await StarterPackClaim.Run(
+                (ulong)pepemonId,
+                supportCardIds,
+                (step, total, action, requiresSignature) =>
+                {
+                    overlay.SetStep(step, total, action, requiresSignature);
+                    SetClaimStatus(action);
+                });
 
             Funnel.Track(Funnel.MintResult, new Dictionary<string, object>
             {
@@ -189,6 +202,10 @@ public class MainMenuController : MonoBehaviour
             if (!result.AssetsGranted)
             {
                 // Nothing irreversible happened, so leave the claim available to retry.
+                overlay.SetResult("Claim did not complete. Nothing was charged.", success: false);
+                await Cysharp.Threading.Tasks.UniTask.Delay(4000, Cysharp.Threading.Tasks.DelayType.Realtime);
+                overlay.Hide();
+
                 FailClaim(result.Error ?? "unknown", "Claim failed. Try again from the Deck screen.");
                 return;
             }
@@ -198,9 +215,15 @@ public class MainMenuController : MonoBehaviour
             OnboardingState.HasClaimedStarterPack = true;
             claimedStarterDeck = true;
 
-            SetClaimStatus(result.DeckIsPlayable
-                ? "Starter pack claimed - your deck is ready!"
-                : "Cards minted. Finish your deck in the Deck screen.");
+            var summary = result.DeckIsPlayable
+                ? "Your deck is ready to battle."
+                : "Cards minted. Finish your deck in the Deck screen.";
+
+            overlay.SetResult(summary, success: true);
+            SetClaimStatus(summary);
+
+            await Cysharp.Threading.Tasks.UniTask.Delay(3500, Cysharp.Threading.Tasks.DelayType.Realtime);
+            overlay.Hide();
 
             if (!result.DeckIsPlayable)
             {
@@ -214,6 +237,12 @@ public class MainMenuController : MonoBehaviour
         catch (Exception e)
         {
             Funnel.Track(Funnel.MintResult, "success", false, "error", e.Message);
+
+            var overlay = ClaimProgressOverlay.Instance;
+            overlay.SetResult("Something went wrong. You can try again.", success: false);
+            await Cysharp.Threading.Tasks.UniTask.Delay(4000, Cysharp.Threading.Tasks.DelayType.Realtime);
+            overlay.Hide();
+
             FailClaim(e.Message, "Claim failed. Try again from the Deck screen.");
         }
     }

--- a/Assets/Scripts/Controllers/ScreenEditDeck.cs
+++ b/Assets/Scripts/Controllers/ScreenEditDeck.cs
@@ -47,23 +47,38 @@ public class ScreenEditDeck : MonoBehaviour
         _mintCardsButton.GetComponent<Button>().onClick.AddListener(HandleMintCardsButtonClick);
     }
 
-    public void LoadAllCards(ulong deckId, int filter)
+    /// <summary>
+    /// Loads a deck into the editor.
+    /// </summary>
+    /// <param name="forceRefresh">
+    /// Re-read ownership from chain even when the deck id has not changed. Required after
+    /// minting: the owned-card fetch is otherwise gated on the deck id changing, so minting
+    /// and reloading the deck you are already viewing showed stale data and the new cards
+    /// never appeared.
+    /// </param>
+    public void LoadAllCards(ulong deckId, int filter, bool forceRefresh = false)
     {
         if (isLoading)
         {
             return;
         }
-        StartCoroutine(LoadAllCardsCoroutine(deckId, filter));
+        StartCoroutine(LoadAllCardsCoroutine(deckId, filter, forceRefresh));
     }
 
-    private IEnumerator LoadAllCardsCoroutine(ulong deckId, int filter)
+    private IEnumerator LoadAllCardsCoroutine(ulong deckId, int filter, bool forceRefresh)
     {
         isLoading = true;
         _textLoading.SetActive(true);
 
+        // Everything below runs inside try/finally so a throw can never strand isLoading at
+        // true - which previously left the screen showing "Loading" forever, unrecoverable
+        // without a scene reload.
+        try
+        {
+
         var deckDisplayComponent = _deckDisplay.GetComponent<DeckDisplay>();
 
-        bool loadingNewDeck = false;
+        bool loadingNewDeck = forceRefresh;
 
         if (currentDeckId != deckId)
         {
@@ -149,7 +164,17 @@ public class ScreenEditDeck : MonoBehaviour
                         }
                     }
 
-                    bool isBattleCard = metadata.Value.description.Contains("Battle ver");
+                    // Metadata can legitimately be missing - a freshly minted id may not be in
+                    // the cache yet. Dereferencing the nullable here used to throw, kill this
+                    // coroutine, and leave the screen stuck on "Loading" permanently.
+                    if (metadata == null)
+                    {
+                        Debug.LogWarning($"[deck] No metadata for card {entry.Key}; treating it as a support card.");
+                        continue;
+                    }
+
+                    var description = metadata.Value.description ?? string.Empty;
+                    bool isBattleCard = description.Contains("Battle ver");
                     if (isBattleCard)
                     {
                         // Add to ownedBattleCardIds
@@ -217,8 +242,12 @@ public class ScreenEditDeck : MonoBehaviour
 
         DeckDisplay.Instance.UpdateCardInDeckDisplay(loadingNewDeck);
 
-        _textLoading.SetActive(false);
-        isLoading = false;
+        }
+        finally
+        {
+            _textLoading.SetActive(false);
+            isLoading = false;
+        }
     }
 
     // Helper method for setting up the starter deck
@@ -287,13 +316,42 @@ public class ScreenEditDeck : MonoBehaviour
         setButtonsInteractibleState(false);
         try
         {
+            SetStatus("Minting cards...");
             await PepemonCardDeck.MintCards();
-            LoadAllCards(currentDeckId, FilterController.Instance.currentFilter);
-        } 
+
+            // forceRefresh: the deck id has not changed, so without this the owned-card fetch
+            // is skipped and the freshly minted cards never show up.
+            SetStatus("Loading your new cards...");
+            LoadAllCards(currentDeckId, FilterController.Instance.currentFilter, forceRefresh: true);
+        }
+        catch (Exception ex)
+        {
+            Debug.LogError($"Unable to mint cards: {ex.Message}");
+            SetStatus("Minting failed. Please try again.");
+        }
         finally
         {
             setButtonsInteractibleState(true);
         }
+    }
+
+    /// <summary>
+    /// Shows a transient message using the existing loading label.
+    ///
+    /// Every failure path here previously did nothing but Debug.LogError, so a rejected or
+    /// reverted transaction looked exactly like success.
+    /// </summary>
+    private void SetStatus(string message)
+    {
+        Debug.Log($"[deck] {message}");
+
+        if (_textLoading == null) return;
+
+        _textLoading.SetActive(!string.IsNullOrEmpty(message));
+
+        var label = _textLoading.GetComponent<TMPro.TMP_Text>();
+        if (label == null) label = _textLoading.GetComponentInChildren<TMPro.TMP_Text>();
+        if (label != null) label.text = message;
     }
     
     public void FilterCards(int filter)
@@ -313,26 +371,35 @@ public class ScreenEditDeck : MonoBehaviour
     {
         setButtonsInteractibleState(false);
 
-        var pepemonCardDeckAddress = Web3Controller.instance.GetChainConfig().pepemonCardDeckAddress;
-
-        // necessary to avoid "ERC1155#safeTransferFrom: INVALID_OPERATOR"
-        // TODO: place this in an "approve" button
-        var approvalOk = await PepemonFactory.GetApprovalState(pepemonCardDeckAddress);
-        if (!approvalOk)
+        // try/finally: the re-enable used to sit after the awaits with no protection, so any
+        // exception that was not an RpcResponseException - a wallet rejection, for instance -
+        // left the Save button disabled for good.
+        try
         {
-            try
-            {
-                await PepemonFactory.SetApprovalState(true, pepemonCardDeckAddress);
-                approvalOk = await PepemonFactory.GetApprovalState(pepemonCardDeckAddress);
-            }
-            catch (Exception ex)
-            {
-                Debug.LogWarning("SetApprovedForAll failed: " + ex.Message);
-            }
-        }
+            var pepemonCardDeckAddress = Web3Controller.instance.GetChainConfig().pepemonCardDeckAddress;
 
-        if (approvalOk)
-        {
+            // necessary to avoid "ERC1155#safeTransferFrom: INVALID_OPERATOR"
+            var approvalOk = await PepemonFactory.GetApprovalState(pepemonCardDeckAddress);
+            if (!approvalOk)
+            {
+                try
+                {
+                    SetStatus("Approving card transfers...");
+                    await PepemonFactory.SetApprovalState(true, pepemonCardDeckAddress);
+                    approvalOk = await PepemonFactory.GetApprovalState(pepemonCardDeckAddress);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogWarning("SetApprovedForAll failed: " + ex.Message);
+                }
+            }
+
+            if (!approvalOk)
+            {
+                SetStatus("Approval declined - deck not saved.");
+                return;
+            }
+
             shouldUpdateTheStarterSupportCardsAfterSave = true;
 
             GetSupportCardsDiff(
@@ -341,21 +408,41 @@ public class ScreenEditDeck : MonoBehaviour
                 out var supportCardsToBeAdded,
                 out var supportCardsToBeRemoved);
 
-            // TODO: wait for transaction receipt
-            if (supportCardsToBeAdded.Length > 0 ||supportCardsToBeRemoved.Length > 0)
-            {
-                await UpdateSupportCards(supportCardsToBeAdded, supportCardsToBeRemoved);
-            }
-            
-            await UpdateBattlecard(_deckDisplay.GetComponent<DeckDisplay>().GetSelectedBattleCard());
-        }
+            var failures = 0;
 
-        setButtonsInteractibleState(true);
+            if (supportCardsToBeAdded.Length > 0 || supportCardsToBeRemoved.Length > 0)
+            {
+                SetStatus("Saving your cards...");
+                failures += await UpdateSupportCards(supportCardsToBeAdded, supportCardsToBeRemoved);
+            }
+
+            SetStatus("Saving your Pepemon...");
+            failures += await UpdateBattlecard(_deckDisplay.GetComponent<DeckDisplay>().GetSelectedBattleCard());
+
+            SetStatus(failures == 0
+                ? "Deck saved."
+                : "Deck partly saved - some changes failed. Check your deck and retry.");
+        }
+        catch (Exception ex)
+        {
+            Debug.LogError($"Unable to save deck: {ex.Message}");
+            SetStatus("Save failed. Please try again.");
+        }
+        finally
+        {
+            setButtonsInteractibleState(true);
+        }
     }
 
-    private async Task UpdateBattlecard(ulong newBattleCard)
+    /// <summary>Returns the number of transactions that failed, so the caller can tell the player.</summary>
+    private async Task<int> UpdateBattlecard(ulong newBattleCard)
     {
-        if (newBattleCard != battleCard && newBattleCard != 0) // 0 is an invalid card
+        if (newBattleCard == battleCard) return 0;
+
+        // Catch Exception rather than only RpcResponseException: a wallet rejection and
+        // thirdweb's WebGL error wrapping are not RpcResponseExceptions, and used to escape
+        // all the way out of the async void click handler.
+        if (newBattleCard != 0) // 0 is an invalid card
         {
             try
             {
@@ -364,34 +451,37 @@ public class ScreenEditDeck : MonoBehaviour
 
                 // update currently selected battlecard in case of success
                 battleCard = newBattleCard;
+                return 0;
             }
-            catch (Nethereum.JsonRpc.Client.RpcResponseException ex)
+            catch (Exception ex)
             {
-                Debug.LogError($"Unable to process transaction: {ex.Message}");
-                // TODO: display error toast
+                Debug.LogError($"Unable to set battle card: {ex.Message}");
+                return 1;
             }
         }
-        else if (newBattleCard != battleCard && newBattleCard == 0)
-        {
-            try
-            {
-                Debug.Log($"Removing battlecard {newBattleCard} on deck {currentDeckId}");
-                await PepemonCardDeck.RemoveBattleCard(currentDeckId);
 
-                // update currently selected battlecard in case of success
-                battleCard = newBattleCard;
-            }
-            catch (Nethereum.JsonRpc.Client.RpcResponseException ex)
-            {
-                Debug.LogError($"Unable to process transaction: {ex.Message}");
-                // TODO: display error toast
-            }
+        try
+        {
+            Debug.Log($"Removing battlecard on deck {currentDeckId}");
+            await PepemonCardDeck.RemoveBattleCard(currentDeckId);
+
+            // update currently selected battlecard in case of success
+            battleCard = newBattleCard;
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Debug.LogError($"Unable to remove battle card: {ex.Message}");
+            return 1;
         }
     }
 
-    private async Task UpdateSupportCards(SupportCardRequest[] supportCardsToBeAdded, 
+    /// <summary>Returns the number of transactions that failed, so the caller can tell the player.</summary>
+    private async Task<int> UpdateSupportCards(SupportCardRequest[] supportCardsToBeAdded,
                                          SupportCardRequest[] supportCardsToBeRemoved)
     {
+        var failures = 0;
+
         if (supportCardsToBeAdded.Count() > 0)
         {
             try
@@ -408,10 +498,10 @@ public class ScreenEditDeck : MonoBehaviour
                     }
                 }
             }
-            catch (Nethereum.JsonRpc.Client.RpcResponseException ex)
+            catch (Exception ex)
             {
                 Debug.LogError($"Unable to process transaction AddSupportCards: {ex.Message}");
-                // TODO: display error toast
+                failures++;
             }
         }
         if (supportCardsToBeRemoved.Count() > 0)
@@ -436,12 +526,14 @@ public class ScreenEditDeck : MonoBehaviour
                     }
                 }
             }
-            catch (Nethereum.JsonRpc.Client.RpcResponseException ex)
+            catch (Exception ex)
             {
                 Debug.LogError($"Unable to process transaction RemoveSupportCards: {ex.Message}");
-                // TODO: display error toast
+                failures++;
             }
         }
+
+        return failures;
     }
 
     public void GetSupportCardsDiff(IDictionary<ulong, int> oldSupportCards, 

--- a/Assets/Scripts/Controllers/ScreenManageDecks.cs
+++ b/Assets/Scripts/Controllers/ScreenManageDecks.cs
@@ -17,7 +17,11 @@ public class ScreenManageDecks : MonoBehaviour
     public void SelectEditDeck(ulong deckId)
     {
         FindObjectOfType<MainMenuController>().ShowScreen(MainSceneScreensEnum.EditDeck);
-        _screenEditDeck.GetComponent<ScreenEditDeck>().LoadAllCards(deckId, FilterController.Instance.currentFilter);
+        // forceRefresh: opening the editor must always re-read ownership from chain. Without
+        // it, re-entering the same deck reused the cached owned-card list, so cards minted
+        // since the last visit never appeared.
+        _screenEditDeck.GetComponent<ScreenEditDeck>()
+            .LoadAllCards(deckId, FilterController.Instance.currentFilter, forceRefresh: true);
     }
 
     public void ReloadAllDecks()

--- a/Assets/Scripts/Onboarding/ClaimProgressOverlay.cs
+++ b/Assets/Scripts/Onboarding/ClaimProgressOverlay.cs
@@ -1,0 +1,162 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Pepemon.Onboarding
+{
+    /// <summary>
+    /// Full-screen progress overlay for the starter-pack claim.
+    ///
+    /// Built entirely in code rather than authored in a scene. The claim runs on the menu
+    /// scene right after a scene load, and the existing status label was never wired up, so
+    /// every progress and failure message went to the console only - the player signed five
+    /// wallet transactions with nothing on screen explaining any of them.
+    ///
+    /// Uses legacy uGUI Text with a built-in font so it has no serialized dependencies and
+    /// cannot silently fail the way a missing TMP font asset would.
+    /// </summary>
+    public class ClaimProgressOverlay : MonoBehaviour
+    {
+        private Text _title;
+        private Text _step;
+        private Text _hint;
+
+        private static ClaimProgressOverlay _instance;
+
+        public static ClaimProgressOverlay Instance
+        {
+            get
+            {
+                if (_instance == null) _instance = Create();
+                return _instance;
+            }
+        }
+
+        private static ClaimProgressOverlay Create()
+        {
+            var root = new GameObject("ClaimProgressOverlay");
+
+            var canvas = root.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            // Above every gameplay canvas, including the tutorial panel at 15.
+            canvas.sortingOrder = 500;
+
+            var scaler = root.AddComponent<CanvasScaler>();
+            scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            scaler.referenceResolution = new Vector2(1920, 1080);
+            scaler.matchWidthOrHeight = 0.5f;
+
+            root.AddComponent<GraphicRaycaster>();
+
+            var overlay = root.AddComponent<ClaimProgressOverlay>();
+
+            // Dim the game behind so it is obvious the claim owns the screen.
+            var backdrop = NewChild(root.transform, "Backdrop");
+            var backdropImage = backdrop.gameObject.AddComponent<Image>();
+            backdropImage.color = new Color(0f, 0f, 0f, 0.82f);
+            Stretch(backdrop);
+
+            var font = BuiltinFont();
+
+            overlay._title = NewLabel(root.transform, "Title", font, 46, FontStyle.Bold,
+                new Vector2(0.5f, 0.62f), new Vector2(1400, 70));
+            overlay._step = NewLabel(root.transform, "Step", font, 34, FontStyle.Normal,
+                new Vector2(0.5f, 0.50f), new Vector2(1400, 120));
+            overlay._hint = NewLabel(root.transform, "Hint", font, 26, FontStyle.Italic,
+                new Vector2(0.5f, 0.38f), new Vector2(1400, 60));
+
+            overlay._hint.color = new Color(1f, 1f, 1f, 0.7f);
+
+            DontDestroyOnLoad(root);
+            root.SetActive(false);
+
+            return overlay;
+        }
+
+        private static Font BuiltinFont()
+        {
+            // LegacyRuntime.ttf is the built-in font from 2021.2 onward; Arial.ttf is the
+            // older name. Try both so this cannot end up with an invisible label.
+            var font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            if (font == null) font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+            return font;
+        }
+
+        private static RectTransform NewChild(Transform parent, string name)
+        {
+            var go = new GameObject(name, typeof(RectTransform));
+            go.transform.SetParent(parent, false);
+            return (RectTransform)go.transform;
+        }
+
+        private static void Stretch(RectTransform rt)
+        {
+            rt.anchorMin = Vector2.zero;
+            rt.anchorMax = Vector2.one;
+            rt.offsetMin = Vector2.zero;
+            rt.offsetMax = Vector2.zero;
+        }
+
+        private static Text NewLabel(Transform parent, string name, Font font, int size,
+            FontStyle style, Vector2 anchor, Vector2 size2d)
+        {
+            var rt = NewChild(parent, name);
+            rt.anchorMin = anchor;
+            rt.anchorMax = anchor;
+            rt.pivot = new Vector2(0.5f, 0.5f);
+            rt.anchoredPosition = Vector2.zero;
+            rt.sizeDelta = size2d;
+
+            var text = rt.gameObject.AddComponent<Text>();
+            text.font = font;
+            text.fontSize = size;
+            text.fontStyle = style;
+            text.alignment = TextAnchor.MiddleCenter;
+            text.horizontalOverflow = HorizontalWrapMode.Wrap;
+            text.verticalOverflow = VerticalWrapMode.Overflow;
+            text.color = Color.white;
+            text.raycastTarget = false;
+
+            return text;
+        }
+
+        /// <summary>Shows the overlay and sets the headline.</summary>
+        public void Show(string title)
+        {
+            gameObject.SetActive(true);
+            if (_title != null) _title.text = title;
+            if (_step != null) _step.text = string.Empty;
+            if (_hint != null) _hint.text = string.Empty;
+        }
+
+        /// <summary>
+        /// Names the action being performed and whether the player is expected to sign.
+        /// The player must always be able to tell what a wallet prompt is for.
+        /// </summary>
+        public void SetStep(int index, int total, string action, bool requiresSignature)
+        {
+            gameObject.SetActive(true);
+
+            if (_step != null) _step.text = $"Step {index} of {total}\n{action}";
+            if (_hint != null)
+            {
+                _hint.text = requiresSignature
+                    ? "Confirm in your wallet to continue"
+                    : "Working - no signature needed";
+            }
+        }
+
+        public void SetResult(string message, bool success)
+        {
+            gameObject.SetActive(true);
+
+            if (_title != null) _title.text = success ? "Starter pack claimed" : "Claim unfinished";
+            if (_step != null) _step.text = message;
+            if (_hint != null) _hint.text = success ? string.Empty : "You can retry from the Deck screen";
+        }
+
+        public void Hide()
+        {
+            gameObject.SetActive(false);
+        }
+    }
+}

--- a/Assets/Scripts/Onboarding/ClaimProgressOverlay.cs.meta
+++ b/Assets/Scripts/Onboarding/ClaimProgressOverlay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fb915ad5e7524adca98b2b274f1c0261
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Onboarding/StarterPackClaim.cs
+++ b/Assets/Scripts/Onboarding/StarterPackClaim.cs
@@ -47,13 +47,21 @@ namespace Pepemon.Onboarding
         private const int DeckPropagationPollMs = 1000;
         private const int DefaultMaxSupportCards = 60;
 
+        /// <summary>Number of stages reported to the player, for "step N of M".</summary>
+        public const int TotalSteps = 7;
+
+        /// <param name="onStep">
+        /// Reports progress as (stepIndex, totalSteps, action, requiresWalletSignature). The
+        /// signature flag matters: the player must always know whether a wallet prompt is
+        /// about to appear and what it is for.
+        /// </param>
         public static async Task<StarterPackClaimResult> Run(
             ulong pepemonId,
             IReadOnlyList<ulong> desiredSupportCardIds,
-            Action<string> onStatus)
+            Action<int, int, string, bool> onStep)
         {
             var result = new StarterPackClaimResult();
-            void Status(string m) => onStatus?.Invoke(m);
+            void Step(int i, string m, bool sig) => onStep?.Invoke(i, TotalSteps, m, sig);
 
             string address;
             try
@@ -87,7 +95,7 @@ namespace Pepemon.Onboarding
             // ---- 1. Mint the cards -------------------------------------------------------
             try
             {
-                Status("Minting your cards...");
+                Step(1, "Minting your cards...", true);
                 await PepemonCardDeck.MintCards();
                 result.CardsMinted = true;
             }
@@ -100,7 +108,7 @@ namespace Pepemon.Onboarding
             // ---- 2. Create the deck that will hold them ----------------------------------
             try
             {
-                Status("Creating your deck...");
+                Step(2, "Creating your deck...", true);
                 await PepemonCardDeck.CreateDeck();
                 result.DeckCreated = true;
             }
@@ -115,7 +123,7 @@ namespace Pepemon.Onboarding
             // and a too-short wait silently assembles nothing.
             try
             {
-                Status("Finding your new deck...");
+                Step(3, "Finding your new deck...", false);
                 result.DeckId = await WaitForNewDeck(address, deckCountBefore);
             }
             catch (Exception e)
@@ -136,7 +144,7 @@ namespace Pepemon.Onboarding
                 var deckAddress = Web3Controller.instance.GetChainConfig().pepemonCardDeckAddress;
                 if (!await PepemonFactory.GetApprovalState(deckAddress))
                 {
-                    Status("Approving card transfers...");
+                    Step(4, "Approving card transfers...", true);
                     await PepemonFactory.SetApprovalState(true, deckAddress);
                 }
             }
@@ -156,7 +164,7 @@ namespace Pepemon.Onboarding
             Dictionary<ulong, int> owned;
             try
             {
-                Status("Checking your new cards...");
+                Step(5, "Checking your new cards...", false);
                 owned = await PepemonFactory.GetOwnedCards(address, candidateIds);
             }
             catch (Exception e)
@@ -175,7 +183,7 @@ namespace Pepemon.Onboarding
             {
                 try
                 {
-                    Status("Adding your Pepemon...");
+                    Step(6, "Adding your Pepemon...", true);
                     await PepemonCardDeck.SetBattleCard(result.DeckId, pepemonId);
                     result.BattleCardSet = true;
                 }
@@ -194,7 +202,7 @@ namespace Pepemon.Onboarding
             {
                 try
                 {
-                    Status("Building your deck...");
+                    Step(7, "Building your deck...", true);
                     await PepemonCardDeck.AddSupportCards(result.DeckId, requests.ToArray());
 
                     foreach (var r in requests) result.SupportCardsAdded += (int)r.Amount;

--- a/Assets/Scripts/UI/Loaders/DeckListLoader.cs
+++ b/Assets/Scripts/UI/Loaders/DeckListLoader.cs
@@ -55,6 +55,15 @@ public class DeckListLoader : MonoBehaviour
             }
         }
         
+        // Everything from here runs inside try/finally. The guard and the loading label were
+        // previously only cleared on the happy path, so a single throw - an RPC hiccup while
+        // reading decks, for instance - left loadingInProgress stuck at true forever. Every
+        // later ReloadAllDecks() then returned immediately at the guard, leaving the player
+        // staring at "Loading decks..." with an empty list for the rest of the session. The
+        // `force` flag exists to work around exactly this; it is no longer the only escape.
+        try
+        {
+
         string account = "";
 
         try
@@ -67,15 +76,21 @@ public class DeckListLoader : MonoBehaviour
         // should not happen, but if it happens then it won't crash the game
         if (string.IsNullOrEmpty(account))
         {
-            loadingMessageLabel.text = "Error: No account selected";
-            //return;
+            loadingMessageLabel.text = "Connect your wallet to see your decks";
+            return;
         }
 
         // load all decks
         List<ulong> decks = new List<ulong>();
-        if (!string.IsNullOrEmpty(account))
+        try
         {
             decks = await PepemonCardDeck.GetPlayerDecks(account);
+        }
+        catch (System.Exception ex)
+        {
+            Debug.LogError($"[decks] Unable to read decks: {ex.Message}");
+            loadingMessageLabel.text = "Could not load your decks. Please retry.";
+            return;
         }
 
         var loadingTasks = new List<UniTask>();
@@ -117,16 +132,48 @@ public class DeckListLoader : MonoBehaviour
             loadingTasks.Add(LoadAndAddDeck(deckInstance, deckId));
         });
         await UniTask.WhenAll(loadingTasks);
+
+        // Tell the player when there is genuinely nothing to pick, rather than showing an
+        // empty screen with no explanation.
+        if (_deckList.transform.childCount == 0)
+        {
+            loadingMessageLabel.text = decks.Count == 0
+                ? "No decks yet - mint one from the Deck screen"
+                : "Your decks could not be loaded. Please retry.";
+            return;
+        }
+
         _loadingMessage.SetActive(false);
-        loadingInProgress = false;
+
+        }
+        finally
+        {
+            loadingInProgress = false;
+        }
     }
 
     private async UniTask LoadAndAddDeck(GameObject deckInstance, ulong deckId)
     {
-        var showDeck = await deckInstance.GetComponent<DeckController>().LoadDeckInfo(deckId, !_deckEditMode);
+        bool showDeck;
+        try
+        {
+            showDeck = await deckInstance.GetComponent<DeckController>().LoadDeckInfo(deckId, !_deckEditMode);
+        }
+        catch (System.Exception ex)
+        {
+            // One bad deck must not take down the whole list.
+            Debug.LogError($"[decks] Unable to load deck {deckId}: {ex.Message}");
+            Destroy(deckInstance);
+            return;
+        }
+
         if (showDeck)
         {
             deckInstance.transform.SetParent(_deckList.transform, false);
+            return;
         }
+
+        // Was instantiated but never parented, so it used to leak at the scene root.
+        Destroy(deckInstance);
     }
 }

--- a/Assets/Scripts/UI/Loaders/DeckListLoader.cs
+++ b/Assets/Scripts/UI/Loaders/DeckListLoader.cs
@@ -16,6 +16,12 @@ public class DeckListLoader : MonoBehaviour
     [TitleGroup("Component References"), SerializeField] GameObject _loadingMessage;
     [TitleGroup("Deck display options"), SerializeField] bool _deckEditMode;
 
+    /// <summary>
+    /// The loading label this list owns, so sibling controls on the same screen can reuse it
+    /// instead of needing their own scene-wired reference.
+    /// </summary>
+    public GameObject LoadingMessage => _loadingMessage;
+
     [ReadOnly] public UnityEvent<ulong> onEditDeck;
     [ReadOnly] public UnityEvent<ulong, bool> onSelectDeck;
     private bool loadingInProgress = false;

--- a/Assets/Scripts/UI/MintDeckButtonHandler.cs
+++ b/Assets/Scripts/UI/MintDeckButtonHandler.cs
@@ -15,16 +15,34 @@ public class MintDeckButtonHandler : MonoBehaviour
         GetComponent<Button>().onClick.AddListener(OnButtonClicked);
     }
 
+    /// <summary>
+    /// Falls back to the deck list's own loading label when no message object is wired.
+    ///
+    /// The live Mint New Deck button has no _loadingMessage assigned - the only wired instance
+    /// sits on an inactive legacy screen - so every progress and failure string this handler
+    /// produced went nowhere. Minting a deck showed no feedback at all while the wallet was
+    /// waiting on a signature.
+    /// </summary>
+    private GameObject ResolveLoadingMessage()
+    {
+        if (_loadingMessage != null) return _loadingMessage;
+        if (_deckList == null) return null;
+
+        var loader = _deckList.GetComponent<DeckListLoader>();
+        return loader != null ? loader.LoadingMessage : null;
+    }
+
     async void OnButtonClicked()
     {
+        var _resolvedLoadingMessage = ResolveLoadingMessage();
         var button = GetComponent<Button>();
         button.interactable = false;
         
         // Show loading message
-        if (_loadingMessage != null)
+        if (_resolvedLoadingMessage != null)
         {
-            _loadingMessage.SetActive(true);
-            var textComponent = _loadingMessage.GetComponent<TMPro.TMP_Text>();
+            _resolvedLoadingMessage.SetActive(true);
+            var textComponent = _resolvedLoadingMessage.GetComponent<TMPro.TMP_Text>();
             if (textComponent != null)
             {
                 textComponent.text = "Minting new deck...";
@@ -39,7 +57,7 @@ public class MintDeckButtonHandler : MonoBehaviour
                 Debug.Log("Wallet not connected. Attempting to connect...");
                 
                 // Update loading message to show connection attempt
-                var textComponent = _loadingMessage?.GetComponent<TMPro.TMP_Text>();
+                var textComponent = _resolvedLoadingMessage?.GetComponent<TMPro.TMP_Text>();
                 if (textComponent != null)
                 {
                     textComponent.text = "Connecting wallet...";
@@ -96,15 +114,24 @@ public class MintDeckButtonHandler : MonoBehaviour
         catch (Exception e)
         {
             Debug.LogError("Unable to mint new deck: " + e.Message);
+
+            // Surface it. The finally below hides the label immediately, so without holding it
+            // here a rejected or reverted mint looked exactly like nothing happening.
+            var errorText = _resolvedLoadingMessage?.GetComponent<TMPro.TMP_Text>();
+            if (errorText != null)
+            {
+                errorText.text = "Could not mint deck. Please try again.";
+                await Cysharp.Threading.Tasks.UniTask.Delay(2500);
+            }
         }
         finally
         {
             button.interactable = true;
             
             // Hide loading message
-            if (_loadingMessage != null)
+            if (_resolvedLoadingMessage != null)
             {
-                _loadingMessage.SetActive(false);
+                _resolvedLoadingMessage.SetActive(false);
             }
         }
     }


### PR DESCRIPTION
Fixes the reported bug that minted cards never appear in the deck builder, plus three reliability failures found in the same screen.

## Reported bug: minted cards never show up

Owned cards are only fetched when `loadingNewDeck` is true, and that is only set when the **deck id changes** ([ScreenEditDeck.cs:68](Assets/Scripts/Controllers/ScreenEditDeck.cs:68)).

- Minting reloads the deck already open → same id → fetch skipped.
- Re-entering the editor from the deck list reuses the same id → fetch skipped.

Both paths rendered the stale `ownedCardIds` field. Added an explicit `forceRefresh`, applied after minting and whenever the editor is opened.

## Also fixed in the same screen

**The editor could hang permanently.** Card metadata can legitimately be missing for a freshly minted id. The nullable was dereferenced after a null check that only guarded the *assignment*, so it threw, killed the coroutine, and left `isLoading` stuck at `true` — "Loading" never cleared and the screen was dead until a scene reload. Guarded, and the coroutine now runs inside `try/finally` so no future throw can strand it.

**A rejected transaction permanently disabled Save.** The re-enable sat after the awaits with no protection, and the catches only handled `RpcResponseException`. A wallet rejection is not one, so it escaped the `async void` handler and the button never came back. Now `try/finally`, catching `Exception`.

**Save failures were invisible.** Every failure path was `Debug.LogError` plus a `// TODO: display error toast`, so a failed save looked identical to a successful one. The transaction helpers now return a failure count and the screen reports saved / partly saved / failed.

Minting and saving also report progress through the existing loading label instead of only the console.

## Reviewer notes

- No behaviour change to the transaction model — this is reliability only. The local-draft + optimistic-UI rewrite is separate.
- `forceRefresh` also resets filters on editor entry, since it takes the full reload path. Intentional: correctness over preserved filter state.
- Not yet covered by tests. The failure paths here are all Unity/coroutine-bound; extracting them cleanly is worth doing but was not in scope for a bug fix.