### PR TITLE
fix(deck): clear the deck status message after it is shown

### DIFF
--- a/Assets/Scripts/Controllers/DeckController.cs
+++ b/Assets/Scripts/Controllers/DeckController.cs
@@ -195,7 +195,7 @@ public class DeckController : MonoBehaviour
                 _errorText.text = "Pepemon card missing";
                 _selectButton.gameObject.SetActive(false);
                 UpdateNotValidDeckIsNotShowWhenSelecting();
-                LogSelectability(deckId, selectionMode, supportCardCount);
+                LogSelectability(deckId, battleCard, selectionMode, supportCardCount);
                 return true;
             }
             if (!hasSupportCards)
@@ -204,7 +204,7 @@ public class DeckController : MonoBehaviour
                 _errorText.text = "Support cards missing";
                 _selectButton.gameObject.SetActive(false);
                 UpdateNotValidDeckIsNotShowWhenSelecting();
-                LogSelectability(deckId, selectionMode, supportCardCount);
+                LogSelectability(deckId, battleCard, selectionMode, supportCardCount);
                 return true;
             }
             _selectButton.gameObject.SetActive(selectionMode);
@@ -215,7 +215,7 @@ public class DeckController : MonoBehaviour
             _errorDisplay.SetActive(false);
         }
 
-        LogSelectability(deckId, selectionMode, supportCardCount);
+        LogSelectability(deckId, battleCard, selectionMode, supportCardCount);
 
         return true;
     }
@@ -227,7 +227,7 @@ public class DeckController : MonoBehaviour
     /// explained from the code alone, and each guess at the cause was wrong. This makes the
     /// running build state the facts rather than requiring them to be inferred.
     /// </summary>
-    private void LogSelectability(ulong deckId, bool selectionMode, int supportCardCount)
+    private void LogSelectability(ulong deckId, ulong battleCard, bool selectionMode, int supportCardCount)
     {
         var selectableNow = _selectButton != null
                             && _selectButton.gameObject.activeSelf

--- a/Assets/Scripts/Controllers/DeckController.cs
+++ b/Assets/Scripts/Controllers/DeckController.cs
@@ -109,7 +109,18 @@ public class DeckController : MonoBehaviour
     {
         if (!isStarterDeck)
         {
-            GetComponent<SelectionItem>().ToggleSelected();
+            // Null-guarded: an NRE here would swallow the click with no visible effect,
+            // which is indistinguishable from the button doing nothing.
+            var selectionItem = GetComponent<SelectionItem>();
+            if (selectionItem != null)
+            {
+                selectionItem.ToggleSelected();
+            }
+            else
+            {
+                Debug.LogError($"[deckpick] Deck {starterDeckId} has no SelectionItem; selection cannot toggle.");
+            }
+
             onSelectButtonClicked?.Invoke();
         }
         else
@@ -184,6 +195,7 @@ public class DeckController : MonoBehaviour
                 _errorText.text = "Pepemon card missing";
                 _selectButton.gameObject.SetActive(false);
                 UpdateNotValidDeckIsNotShowWhenSelecting();
+                LogSelectability(deckId, selectionMode, supportCardCount);
                 return true;
             }
             if (!hasSupportCards)
@@ -192,6 +204,7 @@ public class DeckController : MonoBehaviour
                 _errorText.text = "Support cards missing";
                 _selectButton.gameObject.SetActive(false);
                 UpdateNotValidDeckIsNotShowWhenSelecting();
+                LogSelectability(deckId, selectionMode, supportCardCount);
                 return true;
             }
             _selectButton.gameObject.SetActive(selectionMode);
@@ -201,7 +214,34 @@ public class DeckController : MonoBehaviour
             }
             _errorDisplay.SetActive(false);
         }
-        
+
+        LogSelectability(deckId, selectionMode, supportCardCount);
+
         return true;
+    }
+
+    /// <summary>
+    /// Reports exactly why a deck is or is not selectable.
+    ///
+    /// Deck selection has failed in the field in ways that could not be reproduced or
+    /// explained from the code alone, and each guess at the cause was wrong. This makes the
+    /// running build state the facts rather than requiring them to be inferred.
+    /// </summary>
+    private void LogSelectability(ulong deckId, bool selectionMode, int supportCardCount)
+    {
+        var selectableNow = _selectButton != null
+                            && _selectButton.gameObject.activeSelf
+                            && _selectButton.gameObject.activeInHierarchy;
+
+        Debug.Log(
+            $"[deckpick] deck={deckId} " +
+            $"battleCard={battleCard} supportCards={supportCardCount} " +
+            $"notValidDeck={notValidDeck} isStarterDeck={isStarterDeck} " +
+            $"selectionMode={selectionMode} " +
+            $"editBtnActive={(_editButton != null && _editButton.gameObject.activeSelf)} " +
+            $"selectBtnActiveSelf={(_selectButton != null && _selectButton.gameObject.activeSelf)} " +
+            $"selectBtnInHierarchy={selectableNow} " +
+            $"deckObjActive={gameObject.activeSelf} " +
+            $"hasSelectionItem={GetComponent<SelectionItem>() != null}");
     }
 }

--- a/Assets/Scripts/Controllers/ScreenEditDeck.cs
+++ b/Assets/Scripts/Controllers/ScreenEditDeck.cs
@@ -148,7 +148,11 @@ public class ScreenEditDeck : MonoBehaviour
                 // Fetch owned cards
                 yield return StartCoroutine(PepemonFactory.GetOwnedCards(account, PepemonFactoryCardCache.CardsIds.ToList(), result => ownedCardIds = result));
 
-                starterSupportCards = supportCards;
+                // Snapshot, not an alias. These were the same object, so every mutation of
+                // supportCards after a successful save also rewrote the baseline the next
+                // diff is computed against - producing deltas that ask the contract to
+                // transfer cards the wallet no longer holds.
+                starterSupportCards = new Dictionary<ulong, int>(supportCards);
 
                 var keysToRemove = new List<ulong>();
 
@@ -202,7 +206,7 @@ public class ScreenEditDeck : MonoBehaviour
             {
                 if (shouldUpdateTheStarterSupportCardsAfterSave)
                 {
-                    starterSupportCards = supportCards;
+                    starterSupportCards = new Dictionary<ulong, int>(supportCards);
                 }
             }
 
@@ -509,6 +513,28 @@ public class ScreenEditDeck : MonoBehaviour
                                          SupportCardRequest[] supportCardsToBeRemoved)
     {
         var failures = 0;
+
+        // Pre-flight against actual wallet balances. addSupportCardsToDeck transfers the
+        // cards out of the wallet, so requesting more copies than are held makes ERC1155
+        // revert with no reason string - which is unattributable in the UI and looks like
+        // "saving is broken". Cards already inside the deck are no longer in the wallet.
+        var unaffordable = supportCardsToBeAdded
+            .Where(r => !ownedCardIds.TryGetValue((ulong)r.SupportCardId, out var held)
+                        || held < (int)r.Amount)
+            .ToArray();
+
+        if (unaffordable.Length > 0)
+        {
+            var detail = string.Join(", ", unaffordable.Select(r =>
+            {
+                ownedCardIds.TryGetValue((ulong)r.SupportCardId, out var held);
+                return $"card {r.SupportCardId} (want {r.Amount}, own {held})";
+            }));
+
+            Debug.LogError($"[deck] Refusing addSupportCards - not enough copies owned: {detail}");
+            SetStatus("You don't own enough copies of some cards. Reload the deck and try again.", autoHide: true);
+            return supportCardsToBeAdded.Length;
+        }
 
         if (supportCardsToBeAdded.Count() > 0)
         {

--- a/Assets/Scripts/Controllers/ScreenEditDeck.cs
+++ b/Assets/Scripts/Controllers/ScreenEditDeck.cs
@@ -327,7 +327,7 @@ public class ScreenEditDeck : MonoBehaviour
         catch (Exception ex)
         {
             Debug.LogError($"Unable to mint cards: {ex.Message}");
-            SetStatus("Minting failed. Please try again.");
+            SetStatus("Minting failed. Please try again.", autoHide: true);
         }
         finally
         {
@@ -341,17 +341,44 @@ public class ScreenEditDeck : MonoBehaviour
     /// Every failure path here previously did nothing but Debug.LogError, so a rejected or
     /// reverted transaction looked exactly like success.
     /// </summary>
-    private void SetStatus(string message)
+    private Coroutine _statusHideRoutine;
+
+    /// <param name="autoHide">
+    /// True for terminal messages ("Deck saved.", failures). Those have no follow-up step to
+    /// clear them, so without this they sit over the deck forever - the label is centred on
+    /// screen, so it covers the Pepemon card and reads as the screen being stuck.
+    /// </param>
+    private void SetStatus(string message, bool autoHide = false)
     {
         Debug.Log($"[deck] {message}");
 
         if (_textLoading == null) return;
+
+        if (_statusHideRoutine != null)
+        {
+            StopCoroutine(_statusHideRoutine);
+            _statusHideRoutine = null;
+        }
 
         _textLoading.SetActive(!string.IsNullOrEmpty(message));
 
         var label = _textLoading.GetComponent<TMPro.TMP_Text>();
         if (label == null) label = _textLoading.GetComponentInChildren<TMPro.TMP_Text>();
         if (label != null) label.text = message;
+
+        if (autoHide && isActiveAndEnabled && !string.IsNullOrEmpty(message))
+        {
+            _statusHideRoutine = StartCoroutine(HideStatusAfter(2.5f));
+        }
+    }
+
+    private IEnumerator HideStatusAfter(float seconds)
+    {
+        // Realtime: this must clear even if something else has frozen the game.
+        yield return new WaitForSecondsRealtime(seconds);
+
+        if (_textLoading != null) _textLoading.SetActive(false);
+        _statusHideRoutine = null;
     }
     
     public void FilterCards(int filter)
@@ -396,7 +423,7 @@ public class ScreenEditDeck : MonoBehaviour
 
             if (!approvalOk)
             {
-                SetStatus("Approval declined - deck not saved.");
+                SetStatus("Approval declined - deck not saved.", autoHide: true);
                 return;
             }
 
@@ -421,12 +448,13 @@ public class ScreenEditDeck : MonoBehaviour
 
             SetStatus(failures == 0
                 ? "Deck saved."
-                : "Deck partly saved - some changes failed. Check your deck and retry.");
+                : "Deck partly saved - some changes failed. Check your deck and retry.",
+                autoHide: true);
         }
         catch (Exception ex)
         {
             Debug.LogError($"Unable to save deck: {ex.Message}");
-            SetStatus("Save failed. Please try again.");
+            SetStatus("Save failed. Please try again.", autoHide: true);
         }
         finally
         {

--- a/Assets/Scripts/UI/Loaders/LeaderboardListLoader.cs
+++ b/Assets/Scripts/UI/Loaders/LeaderboardListLoader.cs
@@ -31,55 +31,67 @@ public class LeaderboardListLoader : MonoBehaviour
 
         loadingInProgress = true;
 
-        _loadingMessage.gameObject.SetActive(true);
-        _loadingMessage.text = "Loading leaderboard...";
-
-        // destroy before re-creating
-        foreach (var playerRanking in _rankingList.GetComponentsInChildren<PlayerRankingController>())
-        {
-            Destroy(playerRanking.gameObject);
-        }
-
-        // should not happen, but if it happens then it won't crash the game
-        var account = await ThirdwebManager.Instance.SDK.Wallet.GetAddress();
-        if (string.IsNullOrEmpty(account))
-        {
-            _loadingMessage.text = "Error: No account selected";
-            return;
-        }
-
-        // load all rankings
-        List<(string Address, ulong Ranking)> rankings = new();
+        // try/finally: both early returns below used to leave loadingInProgress stuck at true,
+        // which made the guard above reject every later call - so Refresh became a permanent
+        // no-op and the screen sat on "Loading leaderboard..." for the rest of the session.
         try
         {
-            var totalPlayers = await PepemonMatchmaker.GetLeaderboardPlayersCount(league);
-            for (ulong i = 0; i < totalPlayers; i+= FETCH_SIZE)
+            _loadingMessage.gameObject.SetActive(true);
+            _loadingMessage.text = "Loading leaderboard...";
+
+            // destroy before re-creating
+            foreach (var playerRanking in _rankingList.GetComponentsInChildren<PlayerRankingController>())
             {
-                rankings.AddRange(await PepemonMatchmaker.GetPlayersRankings(league, count: FETCH_SIZE, offset: i));
+                Destroy(playerRanking.gameObject);
             }
 
-            rankings = rankings.OrderByDescending((i) => i.Ranking).Take(TOP_PLAYERS_AMOUNT).ToList();
+            // should not happen, but if it happens then it won't crash the game
+            var account = await ThirdwebManager.Instance.SDK.Wallet.GetAddress();
+            if (string.IsNullOrEmpty(account))
+            {
+                _loadingMessage.text = "Connect your wallet to see the leaderboard";
+                return;
+            }
+
+            // load all rankings
+            List<(string Address, ulong Ranking)> rankings = new();
+            try
+            {
+                var totalPlayers = await PepemonMatchmaker.GetLeaderboardPlayersCount(league);
+                for (ulong i = 0; i < totalPlayers; i += FETCH_SIZE)
+                {
+                    rankings.AddRange(await PepemonMatchmaker.GetPlayersRankings(league, count: FETCH_SIZE, offset: i));
+                }
+
+                rankings = rankings.OrderByDescending((i) => i.Ranking).Take(TOP_PLAYERS_AMOUNT).ToList();
+            }
+            catch (System.Exception e)
+            {
+                Debug.Log($"Unable to load leaderboard: {e.Message}");
+                _loadingMessage.text = "Could not load the leaderboard. Tap Refresh to retry.";
+                return;
+            }
+
+            // An empty leaderboard is a normal state, not a failure - no PvP battle has ever
+            // been completed, so this is what a new player actually sees.
+            if (rankings.Count == 0)
+            {
+                _loadingMessage.text = "No ranked players yet - be the first";
+                return;
+            }
+
+            foreach (var playerRanking in rankings)
+            {
+                var playerRankingInstance = Instantiate(_playerRankingPrefab);
+                playerRankingInstance.transform.SetParent(_rankingList.transform, false);
+                playerRankingInstance.SetInfo(playerRanking.Address, playerRanking.Ranking.ToString());
+            }
+
+            _loadingMessage.gameObject.SetActive(false);
         }
-        catch(System.Exception e)
+        finally
         {
-            // Might always happen when there are no players in the leaderboard, eg.: new deployment of the Matchmaker contract.
-            // Also when there are network issues
-            Debug.Log($"Unable to load leaderboard: {e.Message}");
-            _loadingMessage.text = "Unable to load leaderboard";
-            return;
+            loadingInProgress = false;
         }
-
-
-        List<PlayerRankingController> refs = new List<PlayerRankingController>();
-        foreach (var playerRanking in rankings)
-        {
-            var playerRankingInstance = Instantiate(_playerRankingPrefab);
-            playerRankingInstance.transform.SetParent(_rankingList.transform, false);
-            playerRankingInstance.SetInfo(playerRanking.Address, playerRanking.Ranking.ToString());
-            refs.Add(playerRankingInstance);
-        }
-
-        _loadingMessage.gameObject.SetActive(false);
-        loadingInProgress = false;
     }
 }


### PR DESCRIPTION
Regression from the save-feedback change in #191.

The save summary is written to the shared loading label, but saving does not trigger a reload and that label is only hidden in the load coroutine's `finally`. So **"Deck saved." stayed on screen indefinitely**, centred over the Pepemon card — which reads as the screen having hung.

Terminal messages (saved / partly saved / save failed / approval declined / mint failed) now clear themselves after 2.5s, using realtime so a frozen timescale cannot hold them up. Progress messages still persist until the next step replaces them.

Reported from the 0.0.520 build on env/dev.