### PR TITLE
fix(decks): actually populate the battle deck picker + correct Store links

### DIFF
--- a/Assets/Scenes/StartScreen.unity
+++ b/Assets/Scenes/StartScreen.unity
@@ -38274,7 +38274,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b8c73fb4c4c9efc4ebd2a0a017dd8e33, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  url: https://pepemon.world/store
+  url: https://pepemon.world/store/boosterpacks
 --- !u!1 &1821620000
 GameObject:
   m_ObjectHideFlags: 0
@@ -41756,7 +41756,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b8c73fb4c4c9efc4ebd2a0a017dd8e33, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  url: https://pepemon.world/shop
+  url: https://pepemon.world/store/boosterpacks
 --- !u!114 &1995598010 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: -5027055833532921953, guid: bd0c3ea3727cf994788abfb333fde35a, type: 3}

--- a/Assets/Scripts/Controllers/MainMenuController.cs
+++ b/Assets/Scripts/Controllers/MainMenuController.cs
@@ -336,16 +336,29 @@ public class MainMenuController : MonoBehaviour
         //
         // Done here rather than at a call site so every route into the screen is covered,
         // including the ShowScreen calls wired directly to buttons in the scene.
-        if (screenId == (int)MainSceneScreensEnum.DeckSelection && _selectDeckListLoader != null)
+        if (screenId == (int)MainSceneScreensEnum.DeckSelection)
         {
-            var selectionLoader = _selectDeckListLoader.GetComponent<DeckListLoader>();
+            // Found by searching the screen itself rather than through _selectDeckListLoader.
+            // That field is public but was never assigned in the scene, so the previous
+            // null-check silently skipped the reload and logged nothing - the picker stayed
+            // empty and every [deckpick] line still read selectionMode=False.
+            var selectionLoader = _selectDeckListLoader != null
+                ? _selectDeckListLoader.GetComponent<DeckListLoader>()
+                : null;
+
+            if (selectionLoader == null && screenId < menuScreens.Count && menuScreens[screenId] != null)
+            {
+                selectionLoader = menuScreens[screenId].GetComponentInChildren<DeckListLoader>(true);
+            }
+
             if (selectionLoader != null)
             {
                 selectionLoader.ReloadAllDecks(force: true);
             }
             else
             {
-                Debug.LogError("[decks] _selectDeckListLoader has no DeckListLoader; the battle deck picker cannot be filled.");
+                Debug.LogError("[decks] No DeckListLoader found on the deck selection screen; " +
+                               "the battle deck picker cannot be filled.");
             }
         }
 


### PR DESCRIPTION
Two changes only; everything else from this branch is already on main via #193.

## 1. The PvE/PvP deck picker fix in #193 never ran

It guarded on `_selectDeckListLoader != null`, and that public field was **never assigned in the scene** — so the reload was skipped silently and nothing was logged.

Confirmed in a 0.0.527 console log: every `[deckpick]` line still reads `selectionMode=False`, and `selectionMode=True` appears **zero times**.

The loader is now located by searching the deck selection screen itself, with the serialized field used only as a hint. A missing loader logs loudly instead of failing quietly.

**To verify:** open the PvE deck screen and check for `selectionMode=True` in the console.

## 2. Store buttons

Mint Deck pointed at `/shop`, Edit Deck at `/store`. Both now `/store/boosterpacks`.

---

Known still-broken, tracked separately: the deck editor still offers cards the wallet no longer owns after a save (`card 25/26/36 want 2, own 0`), so a second save fails.