### PR TITLE
feat(store): in-game booster pack store

### DIFF
--- a/Assets/Scenes/StartScreen.unity
+++ b/Assets/Scenes/StartScreen.unity
@@ -27620,6 +27620,7 @@ MonoBehaviour:
       - 0x4fB8b44149750e247A5Cde33DBc0aDC0FF38720a
       - 0xB36F1496196667C992D31467f1fdD96A990A02ef
     - chainId: 84532
+      pepemonBoosterPackAddress: 0xd325B92A8e4FB022d5b5f3204C7f820C71760858
       chainName: Base Sepolia Testnet
       chainCurrencyName: ETH
       chainCurrencySymbol: ETH

--- a/Assets/Scripts/Contracts/PepemonBoosterPack.cs
+++ b/Assets/Scripts/Contracts/PepemonBoosterPack.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Numerics;
+using System.Threading.Tasks;
+using Pepemon.Store;
+using Thirdweb;
+using UnityEngine;
+
+/// <summary>
+/// Booster pack store contract.
+///
+/// Packs mint onto the same PepemonFactory the game already reads, so cards bought here appear
+/// in the deck editor with no extra step. Nothing about decks, battles or the matchmaker changes.
+///
+/// The ABI lives here rather than in Web3Settings because it is a property of the contract
+/// source, not of a particular deployment - unlike the address, which is per chain. That also
+/// keeps a large JSON blob out of scene YAML, where a hand-editing slip stays invisible until a
+/// build runs.
+/// </summary>
+public static class PepemonBoosterPack
+{
+    /// <summary>
+    /// Pack gas is data-dependent: the roll decides which cards move, and which storage slots
+    /// are already warm decides what that costs. The seed also changes between the wallet's gas
+    /// estimation and execution, so an estimate can be made against a cheaper roll than the one
+    /// that actually runs. Measured cost settles around 1.3-1.5M with a first-purchase spike
+    /// near 2.9M, so this is roughly double the worst observed case. Without the explicit limit,
+    /// purchases fail intermittently and the player pays for nothing.
+    /// </summary>
+    public const long GasLimit = 6000000;
+
+    private const string Abi =
+        @"[{""anonymous"":false,""inputs"":[{""indexed"":true,""internalType"":""address"",""name"":""buyer"",""type"":""address""},{""indexed"":true,""internalType"":""uint8"",""name"":""tier"",""type"":""uint8""},{""indexed"":false,""internalType"":""uint256[]"",""name"":""cardIds"",""type"":""uint256[]""}],""name"":""PackOpened"",""type"":""event""},{""inputs"":[{""internalType"":""uint8"",""name"":""tierId"",""type"":""uint8""}],""name"":""mintPack"",""outputs"":[],""stateMutability"":""payable"",""type"":""function""},{""inputs"":[{""internalType"":""uint8"",""name"":""tierId"",""type"":""uint8""}],""name"":""packSize"",""outputs"":[{""internalType"":""uint256"",""name"":"""",""type"":""uint256""}],""stateMutability"":""view"",""type"":""function""},{""inputs"":[{""internalType"":""uint8"",""name"":""tierId"",""type"":""uint8""}],""name"":""tierEnabled"",""outputs"":[{""internalType"":""bool"",""name"":"""",""type"":""bool""}],""stateMutability"":""view"",""type"":""function""},{""inputs"":[{""internalType"":""uint8"",""name"":""tierId"",""type"":""uint8""}],""name"":""tierPrice"",""outputs"":[{""internalType"":""uint256"",""name"":"""",""type"":""uint256""}],""stateMutability"":""view"",""type"":""function""}]";
+
+    /// <summary>One tier as shown in the store: shop copy merged with live contract values.</summary>
+    public class Tier
+    {
+        public byte Id;
+        public string Name;
+        public string Tagline;
+        public string Contents;
+        public BigInteger PriceWei;
+        public int CardCount;
+
+        public string PriceEth => EthDisplay.FormatEth(PriceWei);
+    }
+
+    public static string Address
+    {
+        get
+        {
+            var controller = Web3Controller.instance;
+            if (controller == null) return null;
+            return controller.GetChainConfig().pepemonBoosterPackAddress;
+        }
+    }
+
+    /// <summary>
+    /// False until a booster contract has been deployed and its address configured for the
+    /// current chain. The store shows an explanatory state rather than throwing.
+    /// </summary>
+    public static bool IsConfigured
+    {
+        get
+        {
+            try
+            {
+                var address = Address;
+                return !string.IsNullOrWhiteSpace(address) &&
+                       address != "0x0000000000000000000000000000000000000000";
+            }
+            catch (Exception)
+            {
+                // GetChainConfig throws for a chain id with no settings entry.
+                return false;
+            }
+        }
+    }
+
+    private static Contract Contract => ThirdwebManager.Instance.SDK.GetContract(Address, Abi);
+
+    /// <summary>
+    /// Reads each tier's live price and size. Tiers the contract reports as disabled are left
+    /// out, so switching one off on chain removes it from the store with no client change.
+    /// </summary>
+    public static async Task<List<Tier>> GetTiers()
+    {
+        var tiers = new List<Tier>();
+
+        foreach (var info in PackCatalogue.Tiers)
+        {
+            try
+            {
+                if (!await Contract.Read<bool>("tierEnabled", info.Id)) continue;
+
+                var price = await Contract.Read<BigInteger>("tierPrice", info.Id);
+                var size = await Contract.Read<BigInteger>("packSize", info.Id);
+
+                tiers.Add(new Tier
+                {
+                    Id = info.Id,
+                    Name = info.Name,
+                    Tagline = info.Tagline,
+                    Contents = info.Contents,
+                    PriceWei = price,
+                    CardCount = (int)size,
+                });
+            }
+            catch (Exception ex)
+            {
+                // One unreadable tier must not take down the whole store.
+                Debug.LogError($"[store] Could not read tier {info.Id}: {ex.Message}");
+            }
+        }
+
+        return tiers;
+    }
+
+    /// <summary>
+    /// Buys and opens one pack. The price must match the contract exactly - it rejects both
+    /// under- and overpayment - so it is always the value read from chain, never an assumption.
+    /// </summary>
+    public static async Task<TransactionResult> MintPack(byte tierId, BigInteger priceWei)
+    {
+        var overrides = new TransactionRequest
+        {
+            value = priceWei.ToString(CultureInfo.InvariantCulture),
+            gasLimit = GasLimit.ToString(CultureInfo.InvariantCulture),
+        };
+
+        return await Contract.Write("mintPack", overrides, tierId);
+    }
+}

--- a/Assets/Scripts/Contracts/PepemonBoosterPack.cs.meta
+++ b/Assets/Scripts/Contracts/PepemonBoosterPack.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3ed7cbc9b1454a008f58fcc79bd25802
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Controllers/ScreenEditDeck.cs
+++ b/Assets/Scripts/Controllers/ScreenEditDeck.cs
@@ -46,6 +46,16 @@ public class ScreenEditDeck : MonoBehaviour
     {
         _saveDeckButton.GetComponent<Button>().onClick.AddListener(HandleSaveButtonClick);
         _mintCardsButton.GetComponent<Button>().onClick.AddListener(HandleMintCardsButtonClick);
+
+        // Hidden now that booster packs are the way to get cards. mintCards() hands out one of
+        // every card in the game for free, so leaving the button next to a paid store would
+        // make the store pointless and teach players that packs are for suckers.
+        //
+        // The listener above is still wired and HandleMintCardsButtonClick still works: the
+        // contract function is permissionless and cannot be disabled without the deployer key,
+        // so hiding the button is the honest description of what this does. Re-enable it from
+        // the inspector if a tester needs a full card set.
+        if (_mintCardsButton != null) _mintCardsButton.SetActive(false);
     }
 
     /// <summary>

--- a/Assets/Scripts/Controllers/Web3Settings.cs
+++ b/Assets/Scripts/Controllers/Web3Settings.cs
@@ -28,6 +28,16 @@ public class Web3Settings
         public long pepemonGasLimit;
         public string pepemonMatchmakerAbi;
         public string[] pepemonMatchmakerAddresses;
+
+        /// <summary>
+        /// Booster pack store. Address only: the ABI is a property of the contract source
+        /// rather than of a deployment, so it lives in PepemonBoosterPack.cs instead of being
+        /// pasted into scene YAML.
+        ///
+        /// Empty until a booster contract is deployed for this chain. The store screen checks
+        /// PepemonBoosterPack.IsConfigured and shows an explanatory state rather than failing.
+        /// </summary>
+        public string pepemonBoosterPackAddress;
     }
 
     public Web3ChainConfig GetChainConfig(int chainId)

--- a/Assets/Scripts/Store.meta
+++ b/Assets/Scripts/Store.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: faf890f682b947a598b8f22277049401
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Store/PackCatalogue.cs
+++ b/Assets/Scripts/Store/PackCatalogue.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Numerics;
+
+namespace Pepemon.Store
+{
+    /// <summary>Shop copy for one pack tier. Prices and sizes come from the contract, not here.</summary>
+    public class PackTierInfo
+    {
+        public byte Id;
+        public string Name;
+        public string Tagline;
+        public string Contents;
+    }
+
+    /// <summary>
+    /// Names, taglines and rarity breakdowns for the store.
+    ///
+    /// Only the descriptive half lives here. Price and pack size are always read from the
+    /// contract, because those two decide whether the transaction succeeds: the contract
+    /// rejects both underpayment and overpayment, so a stale price in the client would mean
+    /// every purchase reverts.
+    /// </summary>
+    public static class PackCatalogue
+    {
+        public static readonly IReadOnlyList<PackTierInfo> Tiers = new List<PackTierInfo>
+        {
+            new PackTierInfo
+            {
+                Id = 1,
+                Name = "STARTER PACK",
+                Tagline = "Cheap way to round out a deck.",
+                Contents = "4 Common + 1 Rare",
+            },
+            new PackTierInfo
+            {
+                Id = 2,
+                Name = "TRAINER PACK",
+                Tagline = "A new Pepemon and a guaranteed Epic.",
+                Contents = "1 Pepemon + 5 Common + 3 Rare + 1 Epic",
+            },
+            new PackTierInfo
+            {
+                Id = 3,
+                Name = "DEGEN PACK",
+                Tagline = "Two Pepemon. Three Epics. Send it.",
+                Contents = "2 Pepemon + 8 Common + 7 Rare + 3 Epic",
+            },
+        };
+    }
+
+    /// <summary>Formats wei for display. Kept engine-free so it can be tested in EditMode.</summary>
+    public static class EthDisplay
+    {
+        private static readonly BigInteger WeiPerEth = BigInteger.Pow(10, 18);
+
+        /// <summary>
+        /// Renders wei as a short ETH string.
+        ///
+        /// Done with integer maths rather than casting wei to decimal: a decimal cannot hold
+        /// 10^18 wei for larger balances, and the prices here are small enough that a naive
+        /// double conversion would render as scientific notation.
+        /// </summary>
+        public static string FormatEth(BigInteger wei, int decimals = 6)
+        {
+            if (wei <= BigInteger.Zero) return "FREE";
+
+            var whole = BigInteger.Divide(wei, WeiPerEth);
+            var remainder = wei - whole * WeiPerEth;
+
+            // Take the leading `decimals` digits of the fractional part.
+            var scale = BigInteger.Pow(10, 18 - decimals);
+            var fraction = BigInteger.Divide(remainder, scale);
+
+            var text = whole.ToString(CultureInfo.InvariantCulture);
+            if (fraction > BigInteger.Zero)
+            {
+                var digits = fraction.ToString(CultureInfo.InvariantCulture).PadLeft(decimals, '0').TrimEnd('0');
+                if (digits.Length > 0) text += "." + digits;
+            }
+
+            return text + " ETH";
+        }
+    }
+}

--- a/Assets/Scripts/Store/PackCatalogue.cs.meta
+++ b/Assets/Scripts/Store/PackCatalogue.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 581755b8888a4bce9437fd8391f5883e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Store/PackLoot.cs
+++ b/Assets/Scripts/Store/PackLoot.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Pepemon.Store
+{
+    public enum CardRarity
+    {
+        Pepemon,
+        Common,
+        Rare,
+        Epic,
+    }
+
+    /// <summary>
+    /// Works out what a player actually received from a pack.
+    ///
+    /// Deliberately free of Unity and chain types so it can be tested in EditMode. The reveal is
+    /// the payoff moment of the whole store, and it is not worth finding out it is wrong from a
+    /// 35-minute cloud build.
+    ///
+    /// Named PackLoot rather than the more obvious PackRewards because the vendored Thirdweb SDK
+    /// already exposes a Thirdweb.PackRewards, and any file with both `using Thirdweb;` and
+    /// `using Pepemon.Store;` then fails to compile on an ambiguous reference.
+    /// </summary>
+    public static class PackLoot
+    {
+        // Rarity per card id, as recorded in the contract repo's deploy/cards.ts. Ids 1-10 are
+        // the Pepemon battle cards; 11-49 are support cards.
+        private static readonly HashSet<ulong> PepemonIds = new HashSet<ulong> { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+
+        private static readonly HashSet<ulong> CommonIds =
+            new HashSet<ulong> { 11, 12, 13, 14, 15, 16, 17, 27, 28, 29 };
+
+        private static readonly HashSet<ulong> RareIds = new HashSet<ulong>
+            { 18, 19, 20, 21, 22, 25, 30, 31, 32, 33, 34, 36, 37, 40, 41, 42, 43, 44, 46, 47, 48 };
+
+        private static readonly HashSet<ulong> EpicIds = new HashSet<ulong> { 23, 24, 26, 35, 38, 39, 45, 49 };
+
+        public static CardRarity RarityOf(ulong cardId)
+        {
+            if (PepemonIds.Contains(cardId)) return CardRarity.Pepemon;
+            if (EpicIds.Contains(cardId)) return CardRarity.Epic;
+            if (RareIds.Contains(cardId)) return CardRarity.Rare;
+            // Anything added to the factory later reads as Common rather than throwing. A new
+            // card should never stop a pack from being revealed.
+            return CardRarity.Common;
+        }
+
+        /// <summary>
+        /// The cards gained between two balance snapshots, one entry per copy received.
+        ///
+        /// Balances are diffed rather than the PackOpened event being decoded: the game already
+        /// reads balances everywhere, whereas event decoding differs between the WebGL bridge
+        /// and native and would need its own code path on each.
+        /// </summary>
+        public static List<ulong> Gained(IDictionary<ulong, int> before, IDictionary<ulong, int> after)
+        {
+            var gained = new List<ulong>();
+            if (after == null) return gained;
+
+            foreach (var entry in after)
+            {
+                var had = 0;
+                if (before != null) before.TryGetValue(entry.Key, out had);
+
+                for (var i = 0; i < entry.Value - had; i++) gained.Add(entry.Key);
+            }
+
+            gained.Sort();
+            return gained;
+        }
+
+        /// <summary>Counts per rarity, richest first, for the reveal summary line.</summary>
+        public static string Summarise(IEnumerable<ulong> cardIds)
+        {
+            if (cardIds == null) return string.Empty;
+
+            var byRarity = cardIds.GroupBy(RarityOf).ToDictionary(g => g.Key, g => g.Count());
+            var parts = new List<string>();
+
+            foreach (var rarity in new[] { CardRarity.Epic, CardRarity.Pepemon, CardRarity.Rare, CardRarity.Common })
+            {
+                if (byRarity.TryGetValue(rarity, out var count) && count > 0)
+                {
+                    parts.Add($"{count} {rarity.ToString().ToUpperInvariant()}");
+                }
+            }
+
+            return string.Join("  ", parts);
+        }
+    }
+}

--- a/Assets/Scripts/Store/PackLoot.cs.meta
+++ b/Assets/Scripts/Store/PackLoot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 70af77e976cc4eb3a9bc03302b79533d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Store/Pepemon.Store.asmdef
+++ b/Assets/Scripts/Store/Pepemon.Store.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "Pepemon.Store",
+    "rootNamespace": "Pepemon.Store",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": true
+}

--- a/Assets/Scripts/Store/Pepemon.Store.asmdef.meta
+++ b/Assets/Scripts/Store/Pepemon.Store.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f6da1247fa364fb48bc489fc6f6d3d9a
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Store/StoreLinks.cs
+++ b/Assets/Scripts/Store/StoreLinks.cs
@@ -1,0 +1,24 @@
+namespace Pepemon.Store
+{
+    /// <summary>
+    /// Decides whether an outbound link should be replaced by the in-game store.
+    ///
+    /// This is not only a convenience. The web shop's booster packs mint onto a different cards
+    /// contract (0xae0b8933...) from the one the game reads (0x888c8302...), so a player who
+    /// followed those links and bought a pack would receive cards the game can never show them.
+    /// Sending them to the in-game store instead is the difference between a sale and a
+    /// support ticket.
+    /// </summary>
+    public static class StoreLinks
+    {
+        public static bool IsStoreLink(string url)
+        {
+            if (string.IsNullOrWhiteSpace(url)) return false;
+
+            var lower = url.ToLowerInvariant();
+            if (lower.IndexOf("pepemon", System.StringComparison.Ordinal) < 0) return false;
+
+            return lower.Contains("/store") || lower.Contains("boosterpack");
+        }
+    }
+}

--- a/Assets/Scripts/Store/StoreLinks.cs.meta
+++ b/Assets/Scripts/Store/StoreLinks.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: beed5fc5085544ab8e70036008343800
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Telemetry/Funnel.cs
+++ b/Assets/Scripts/Telemetry/Funnel.cs
@@ -69,6 +69,15 @@ namespace Pepemon.Telemetry
         public const string WalletConnectResult = "wallet_connect_result";
         public const string MintResult = "mint_result";
         public const string ReturnedToMenu = "returned_to_menu";
+
+        // Booster pack store. The purchase funnel is the one place in the game where a player
+        // spends real value, so each step is separated: how many open the store, how many press
+        // buy, how many confirm in the wallet, and how many actually see cards.
+        public const string StoreOpened = "store_opened";
+        public const string PackTierViewed = "pack_tier_viewed";
+        public const string PackPurchaseStarted = "pack_purchase_started";
+        public const string PackPurchaseResult = "pack_purchase_result";
+        public const string PackRevealed = "pack_revealed";
         #endregion
 
         private static ITelemetryBackend _backend = new DebugLogTelemetryBackend();

--- a/Assets/Scripts/UI/OpenLinkButton.cs
+++ b/Assets/Scripts/UI/OpenLinkButton.cs
@@ -1,5 +1,5 @@
-using System.Collections;
-using System.Collections.Generic;
+using Pepemon.Store;
+using Pepemon.UI;
 using UnityEngine;
 
 public class OpenLinkButton : MonoBehaviour
@@ -8,6 +8,18 @@ public class OpenLinkButton : MonoBehaviour
 
     public void OpenLink()
     {
+        // Store links open the in-game booster store rather than the web shop. The web shop's
+        // packs mint onto a different cards contract from the one this game reads, so a player
+        // who bought there would receive cards the game can never show them.
+        //
+        // Matched on the URL rather than rewired in the scene: every hard-to-find bug in this
+        // project has been a scene reference, and a code path is at least visible in review.
+        if (StoreLinks.IsStoreLink(url))
+        {
+            BoosterStoreScreen.Instance.Open();
+            return;
+        }
+
         Application.OpenURL(url);
     }
 }

--- a/Assets/Scripts/UI/Store.meta
+++ b/Assets/Scripts/UI/Store.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 14b4b2d177a840b185b53381f2a54b08
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Store/BoosterStoreScreen.cs
+++ b/Assets/Scripts/UI/Store/BoosterStoreScreen.cs
@@ -1,0 +1,537 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
+using Pepemon.Store;
+using Pepemon.Telemetry;
+using Thirdweb;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Pepemon.UI
+{
+    /// <summary>
+    /// In-game booster pack store.
+    ///
+    /// Built entirely in code, like PixelNotice, so it needs no scene wiring. That is not a
+    /// stylistic choice: every hard-to-find bug in this project so far has been a serialized
+    /// reference left unassigned or a checkbox set the wrong way, none of which is visible when
+    /// reading C#, and each of which cost a full cloud build to discover. A screen with no scene
+    /// references cannot fail that way.
+    /// </summary>
+    public class BoosterStoreScreen : MonoBehaviour
+    {
+        private static readonly Color Scrim = new Color32(0x08, 0x04, 0x14, 0xE6);
+        private static readonly Color PanelFill = new Color32(0x1B, 0x10, 0x35, 0xFF);
+        private static readonly Color PanelBorder = new Color32(0x7C, 0xE0, 0x4B, 0xFF);
+        private static readonly Color CardFill = new Color32(0x24, 0x16, 0x45, 0xFF);
+        private static readonly Color TitleColor = new Color32(0x9B, 0xF2, 0x6B, 0xFF);
+        private static readonly Color BodyColor = new Color32(0xE8, 0xE8, 0xE8, 0xFF);
+        private static readonly Color MutedColor = new Color32(0x9A, 0x8F, 0xB8, 0xFF);
+        private static readonly Color BuyFill = new Color32(0x3F, 0xA9, 0x2E, 0xFF);
+        private static readonly Color BuyDisabled = new Color32(0x4A, 0x44, 0x5C, 0xFF);
+        private static readonly Color CloseFill = new Color32(0x5A, 0x2A, 0x3A, 0xFF);
+
+        private static readonly Color[] RarityColors =
+        {
+            new Color32(0xFF, 0xD5, 0x4A, 0xFF), // Pepemon
+            new Color32(0xC9, 0xC9, 0xC9, 0xFF), // Common
+            new Color32(0x6B, 0xC5, 0xF2, 0xFF), // Rare
+            new Color32(0xE0, 0x6B, 0xF2, 0xFF), // Epic
+        };
+
+        private RectTransform _packRow;
+        private RectTransform _revealPanel;
+        private RectTransform _revealGrid;
+        private TMP_Text _status;
+        private TMP_Text _revealTitle;
+        private TMP_Text _revealSummary;
+        private TMP_FontAsset _font;
+
+        private bool _busy;
+        private readonly List<Button> _buyButtons = new List<Button>();
+
+        private static BoosterStoreScreen _instance;
+
+        public static BoosterStoreScreen Instance
+        {
+            get
+            {
+                if (_instance == null) _instance = Build();
+                return _instance;
+            }
+        }
+
+        #region construction
+
+        private static TMP_FontAsset GameFont()
+        {
+            if (TMP_Settings.defaultFontAsset != null) return TMP_Settings.defaultFontAsset;
+            var fonts = Resources.FindObjectsOfTypeAll<TMP_FontAsset>();
+            return fonts != null && fonts.Length > 0 ? fonts[0] : null;
+        }
+
+        private static BoosterStoreScreen Build()
+        {
+            var root = new GameObject("BoosterStore");
+
+            var canvas = root.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            // Above the game UI but below PixelNotice, so an error notice still reads on top.
+            canvas.sortingOrder = 350;
+
+            var scaler = root.AddComponent<CanvasScaler>();
+            scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            scaler.referenceResolution = new Vector2(1920, 1080);
+            scaler.matchWidthOrHeight = 0.5f;
+
+            root.AddComponent<GraphicRaycaster>();
+
+            var screen = root.AddComponent<BoosterStoreScreen>();
+            screen._font = GameFont();
+
+            // Full-screen scrim, so clicks cannot reach the menu behind the store.
+            var scrim = Stretch(root.transform, "Scrim");
+            scrim.gameObject.AddComponent<Image>().color = Scrim;
+
+            var border = Panel(root.transform, PanelBorder, new Vector2(1560, 860));
+            var fill = Stretch(border, "Fill", 6);
+            fill.gameObject.AddComponent<Image>().color = PanelFill;
+
+            Label(fill, screen._font, 54, TitleColor, new Vector2(0.5f, 0.93f), new Vector2(1200, 70), "BOOSTER PACKS");
+            Label(fill, screen._font, 26, MutedColor, new Vector2(0.5f, 0.86f), new Vector2(1300, 50),
+                "Cards mint straight to your wallet. Build them into a deck from the Deck screen.");
+
+            screen._packRow = Row(fill);
+            screen._status = Label(fill, screen._font, 30, BodyColor, new Vector2(0.5f, 0.5f), new Vector2(1200, 200), "");
+
+            var close = TextButton(fill, screen._font, CloseFill, new Vector2(0.94f, 0.93f), new Vector2(90, 64), "X", 34);
+            close.onClick.AddListener(screen.Close);
+
+            screen.BuildReveal(root.transform);
+
+            DontDestroyOnLoad(root);
+            root.SetActive(false);
+            return screen;
+        }
+
+        private void BuildReveal(Transform parent)
+        {
+            var border = Panel(parent, PanelBorder, new Vector2(1400, 800));
+            _revealPanel = border;
+
+            var fill = Stretch(border, "Fill", 6);
+            fill.gameObject.AddComponent<Image>().color = PanelFill;
+
+            _revealTitle = Label(fill, _font, 56, TitleColor, new Vector2(0.5f, 0.92f), new Vector2(1200, 70), "");
+            _revealSummary = Label(fill, _font, 30, BodyColor, new Vector2(0.5f, 0.85f), new Vector2(1200, 50), "");
+
+            var gridGo = new GameObject("Grid", typeof(RectTransform));
+            gridGo.transform.SetParent(fill, false);
+            _revealGrid = (RectTransform)gridGo.transform;
+            _revealGrid.anchorMin = new Vector2(0.5f, 0.45f);
+            _revealGrid.anchorMax = new Vector2(0.5f, 0.45f);
+            _revealGrid.pivot = new Vector2(0.5f, 0.5f);
+            _revealGrid.sizeDelta = new Vector2(1240, 520);
+
+            var grid = gridGo.AddComponent<GridLayoutGroup>();
+            grid.cellSize = new Vector2(140, 200);
+            grid.spacing = new Vector2(14, 14);
+            grid.childAlignment = TextAnchor.MiddleCenter;
+            grid.constraint = GridLayoutGroup.Constraint.FixedColumnCount;
+            grid.constraintCount = 8;
+
+            var done = TextButton(fill, _font, BuyFill, new Vector2(0.5f, 0.09f), new Vector2(420, 76), "NICE", 32);
+            done.onClick.AddListener(() =>
+            {
+                _revealPanel.gameObject.SetActive(false);
+                Refresh();
+            });
+
+            border.gameObject.SetActive(false);
+        }
+
+        #endregion
+
+        #region ui primitives
+
+        private static RectTransform Stretch(Transform parent, string name, float inset = 0f)
+        {
+            var go = new GameObject(name, typeof(RectTransform));
+            go.transform.SetParent(parent, false);
+            var rt = (RectTransform)go.transform;
+            rt.anchorMin = Vector2.zero;
+            rt.anchorMax = Vector2.one;
+            rt.offsetMin = new Vector2(inset, inset);
+            rt.offsetMax = new Vector2(-inset, -inset);
+            return rt;
+        }
+
+        private static RectTransform Panel(Transform parent, Color color, Vector2 size)
+        {
+            var go = new GameObject("Panel", typeof(RectTransform));
+            go.transform.SetParent(parent, false);
+            var rt = (RectTransform)go.transform;
+            rt.anchorMin = rt.anchorMax = new Vector2(0.5f, 0.5f);
+            rt.pivot = new Vector2(0.5f, 0.5f);
+            rt.anchoredPosition = Vector2.zero;
+            rt.sizeDelta = size;
+            go.AddComponent<Image>().color = color;
+            return rt;
+        }
+
+        private static RectTransform Row(Transform parent)
+        {
+            var go = new GameObject("PackRow", typeof(RectTransform));
+            go.transform.SetParent(parent, false);
+            var rt = (RectTransform)go.transform;
+            rt.anchorMin = rt.anchorMax = new Vector2(0.5f, 0.46f);
+            rt.pivot = new Vector2(0.5f, 0.5f);
+            rt.sizeDelta = new Vector2(1440, 560);
+
+            var layout = go.AddComponent<HorizontalLayoutGroup>();
+            layout.spacing = 32;
+            layout.childAlignment = TextAnchor.MiddleCenter;
+            layout.childForceExpandWidth = false;
+            layout.childForceExpandHeight = false;
+            layout.childControlWidth = false;
+            layout.childControlHeight = false;
+            return rt;
+        }
+
+        private static TMP_Text Label(Transform parent, TMP_FontAsset font, int size, Color color,
+            Vector2 anchor, Vector2 box, string text)
+        {
+            var go = new GameObject("Label", typeof(RectTransform));
+            go.transform.SetParent(parent, false);
+            var rt = (RectTransform)go.transform;
+            rt.anchorMin = rt.anchorMax = anchor;
+            rt.pivot = new Vector2(0.5f, 0.5f);
+            rt.anchoredPosition = Vector2.zero;
+            rt.sizeDelta = box;
+
+            var t = go.AddComponent<TextMeshProUGUI>();
+            if (font != null) t.font = font;
+            t.fontSize = size;
+            t.color = color;
+            t.alignment = TextAlignmentOptions.Center;
+            t.enableWordWrapping = true;
+            t.raycastTarget = false;
+            t.text = text ?? string.Empty;
+            return t;
+        }
+
+        private static Button TextButton(Transform parent, TMP_FontAsset font, Color fill, Vector2 anchor,
+            Vector2 size, string caption, int fontSize)
+        {
+            var go = new GameObject("Button", typeof(RectTransform));
+            go.transform.SetParent(parent, false);
+            var rt = (RectTransform)go.transform;
+            rt.anchorMin = rt.anchorMax = anchor;
+            rt.pivot = new Vector2(0.5f, 0.5f);
+            rt.anchoredPosition = Vector2.zero;
+            rt.sizeDelta = size;
+
+            var img = go.AddComponent<Image>();
+            img.color = fill;
+
+            var btn = go.AddComponent<Button>();
+            btn.targetGraphic = img;
+
+            Label(rt, font, fontSize, Color.white, new Vector2(0.5f, 0.5f), size, caption);
+            return btn;
+        }
+
+        #endregion
+
+        #region flow
+
+        public void Open()
+        {
+            gameObject.SetActive(true);
+            _revealPanel.gameObject.SetActive(false);
+            Funnel.Track(Funnel.StoreOpened);
+            Refresh();
+        }
+
+        public void Close()
+        {
+            gameObject.SetActive(false);
+        }
+
+        private async void Refresh()
+        {
+            ClearPacks();
+
+            if (!PepemonBoosterPack.IsConfigured)
+            {
+                // Honest empty state. The contract may simply not be deployed on this network
+                // yet, and that is not the player's problem to decode from an exception.
+                SetStatus("Booster packs are not live on this network yet.\nCheck back soon.");
+                return;
+            }
+
+            string account = null;
+            try
+            {
+                account = await ThirdwebManager.Instance.SDK.Wallet.GetAddress();
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[store] Could not read wallet address: {ex.Message}");
+            }
+
+            if (string.IsNullOrEmpty(account))
+            {
+                SetStatus("Connect your wallet to buy packs.");
+                PixelNotice.Instance.Show(
+                    "No wallet connected",
+                    "Connect your wallet to buy booster packs.",
+                    "CONNECT WALLET",
+                    async () =>
+                    {
+                        if (Web3Controller.instance == null) return;
+                        await Web3Controller.instance.ConnectWallet();
+                        if (Web3Controller.instance.IsConnected) Refresh();
+                    });
+                return;
+            }
+
+            SetStatus("Loading packs...");
+
+            List<PepemonBoosterPack.Tier> tiers;
+            try
+            {
+                tiers = await PepemonBoosterPack.GetTiers();
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[store] Could not load tiers: {ex.Message}");
+                SetStatus("Could not reach the store. Please retry.");
+                return;
+            }
+
+            if (tiers == null || tiers.Count == 0)
+            {
+                SetStatus("No packs are on sale right now.");
+                return;
+            }
+
+            SetStatus("");
+            foreach (var tier in tiers) AddPackCard(tier);
+        }
+
+        private void ClearPacks()
+        {
+            _buyButtons.Clear();
+            if (_packRow == null) return;
+
+            for (var i = _packRow.childCount - 1; i >= 0; i--)
+            {
+                Destroy(_packRow.GetChild(i).gameObject);
+            }
+        }
+
+        private void SetStatus(string message)
+        {
+            if (_status == null) return;
+            _status.text = message ?? string.Empty;
+            _status.gameObject.SetActive(!string.IsNullOrEmpty(message));
+        }
+
+        private void AddPackCard(PepemonBoosterPack.Tier tier)
+        {
+            var go = new GameObject($"Pack{tier.Id}", typeof(RectTransform));
+            go.transform.SetParent(_packRow, false);
+            var rt = (RectTransform)go.transform;
+            rt.sizeDelta = new Vector2(440, 520);
+            go.AddComponent<Image>().color = CardFill;
+
+            Label(rt, _font, 38, TitleColor, new Vector2(0.5f, 0.88f), new Vector2(400, 60), tier.Name);
+            Label(rt, _font, 24, MutedColor, new Vector2(0.5f, 0.78f), new Vector2(380, 60), tier.Tagline);
+            Label(rt, _font, 46, BodyColor, new Vector2(0.5f, 0.62f), new Vector2(380, 70), $"{tier.CardCount} CARDS");
+            Label(rt, _font, 24, BodyColor, new Vector2(0.5f, 0.48f), new Vector2(390, 100), tier.Contents);
+            Label(rt, _font, 40, TitleColor, new Vector2(0.5f, 0.28f), new Vector2(380, 60), tier.PriceEth);
+
+            var buy = TextButton(rt, _font, BuyFill, new Vector2(0.5f, 0.12f), new Vector2(360, 76), "BUY", 32);
+            var captured = tier;
+            buy.onClick.AddListener(() => Buy(captured));
+            _buyButtons.Add(buy);
+
+            Funnel.Track(Funnel.PackTierViewed, "tier", tier.Id, "price_wei", tier.PriceWei.ToString());
+        }
+
+        private void SetBuyEnabled(bool enabled)
+        {
+            _busy = !enabled;
+            foreach (var button in _buyButtons)
+            {
+                if (button == null) continue;
+                button.interactable = enabled;
+                var image = button.targetGraphic as Image;
+                if (image != null) image.color = enabled ? BuyFill : BuyDisabled;
+            }
+        }
+
+        private async void Buy(PepemonBoosterPack.Tier tier)
+        {
+            if (_busy) return;
+
+            SetBuyEnabled(false);
+            SetStatus($"Opening {tier.Name}... confirm in your wallet.");
+            Funnel.Track(Funnel.PackPurchaseStarted, "tier", tier.Id);
+
+            var cardIds = new List<ulong>();
+            try
+            {
+                var account = await ThirdwebManager.Instance.SDK.Wallet.GetAddress();
+
+                // Balances are snapshotted around the purchase and diffed. The PackOpened event
+                // carries the same information, but decoding logs differs between the WebGL
+                // bridge and native, and balance reads are already used all over the game.
+                var probeIds = await AllCardIds();
+                var before = await PepemonFactory.GetOwnedCards(account, probeIds);
+
+                await PepemonBoosterPack.MintPack(tier.Id, tier.PriceWei);
+
+                SetStatus("Opening pack...");
+                var after = await PepemonFactory.GetOwnedCards(account, probeIds);
+                cardIds = PackLoot.Gained(before, after);
+
+                Funnel.Track(Funnel.PackPurchaseResult, "tier", tier.Id, "success", true, "cards", cardIds.Count);
+            }
+            catch (Exception ex)
+            {
+                var message = ex.Message ?? string.Empty;
+                var rejected = message.IndexOf("reject", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                               message.IndexOf("denied", StringComparison.OrdinalIgnoreCase) >= 0;
+
+                Debug.LogError($"[store] Pack purchase failed: {message}");
+                Funnel.Track(Funnel.PackPurchaseResult, "tier", tier.Id, "success", false, "error", message);
+
+                SetStatus("");
+                SetBuyEnabled(true);
+
+                PixelNotice.Instance.Show(
+                    rejected ? "Purchase cancelled" : "Purchase failed",
+                    rejected
+                        ? "You cancelled the transaction in your wallet. Nothing was charged."
+                        : "The transaction did not go through. You have not been charged for a pack you did not receive.",
+                    "OK",
+                    () => { });
+                return;
+            }
+
+            SetBuyEnabled(true);
+            SetStatus("");
+
+            if (cardIds.Count == 0)
+            {
+                // The transaction succeeded but no new balance showed up. Rather than claim a
+                // reward we cannot see, say so and point at the deck editor.
+                PixelNotice.Instance.Show(
+                    "Pack opened",
+                    "Your pack went through, but the new cards have not shown up yet. They should appear in the Deck screen shortly.",
+                    "OK",
+                    () => { });
+                return;
+            }
+
+            ShowReveal(tier, cardIds);
+        }
+
+        /// <summary>Card ids to probe when diffing balances, read from the factory rather than assumed.</summary>
+        private static async Task<List<ulong>> AllCardIds()
+        {
+            ulong last = 49;
+            try
+            {
+                last = await PepemonFactory.GetLastCardId();
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[store] Could not read last card id, assuming {last}: {ex.Message}");
+            }
+
+            var ids = new List<ulong>();
+            for (ulong id = 1; id <= last; id++) ids.Add(id);
+            return ids;
+        }
+
+        #endregion
+
+        #region reveal
+
+        private void ShowReveal(PepemonBoosterPack.Tier tier, List<ulong> cardIds)
+        {
+            Funnel.Track(Funnel.PackRevealed, "tier", tier.Id, "cards", cardIds.Count,
+                "summary", PackLoot.Summarise(cardIds));
+
+            _revealTitle.text = "YOU PULLED";
+            _revealSummary.text = PackLoot.Summarise(cardIds);
+
+            for (var i = _revealGrid.childCount - 1; i >= 0; i--)
+            {
+                Destroy(_revealGrid.GetChild(i).gameObject);
+            }
+
+            foreach (var cardId in cardIds) AddRevealCard(cardId);
+
+            _revealPanel.gameObject.SetActive(true);
+        }
+
+        private void AddRevealCard(ulong cardId)
+        {
+            var go = new GameObject($"Card{cardId}", typeof(RectTransform));
+            go.transform.SetParent(_revealGrid, false);
+
+            var rarity = PackLoot.RarityOf(cardId);
+            go.AddComponent<Image>().color = RarityColors[(int)rarity];
+
+            var inner = Stretch(go.transform, "Inner", 4);
+            var art = inner.gameObject.AddComponent<Image>();
+            art.color = CardFill;
+
+            var texture = SafeImage(cardId);
+            if (texture != null)
+            {
+                art.sprite = Sprite.Create(texture, new Rect(0, 0, texture.width, texture.height),
+                    new Vector2(0.5f, 0.5f));
+                art.color = Color.white;
+            }
+
+            var name = CardName(cardId);
+            Label(inner, _font, 15, BodyColor, new Vector2(0.5f, 0.07f), new Vector2(128, 40), name);
+        }
+
+        private static Texture2D SafeImage(ulong cardId)
+        {
+            try
+            {
+                return PepemonFactoryCardCache.GetImage(cardId);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        private static string CardName(ulong cardId)
+        {
+            try
+            {
+                var metadata = PepemonFactoryCardCache.GetMetadata(cardId);
+                if (metadata != null && !string.IsNullOrEmpty(metadata.Value.name)) return metadata.Value.name;
+            }
+            catch (Exception)
+            {
+                // Falls through to the id, which is still better than a blank card.
+            }
+
+            return $"#{cardId}";
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/UI/Store/BoosterStoreScreen.cs.meta
+++ b/Assets/Scripts/UI/Store/BoosterStoreScreen.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2517ba73634a4a80b3bcbdf77a345c4e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/PackLootTests.cs
+++ b/Assets/Tests/EditMode/PackLootTests.cs
@@ -1,0 +1,232 @@
+using System.Collections.Generic;
+using System.Numerics;
+using NUnit.Framework;
+using Pepemon.Store;
+
+/// <summary>
+/// Covers the booster store logic that can be checked without a chain or a scene.
+///
+/// The reveal is the payoff moment of the whole store, and the price is what decides whether a
+/// purchase succeeds at all - the contract rejects underpayment and overpayment alike. Neither
+/// is worth discovering is wrong from a 35-minute cloud build.
+/// </summary>
+public class PackLootTests
+{
+    #region rarity
+
+    [Test]
+    public void BattleCardIdsAreRecognisedAsPepemon()
+    {
+        for (ulong id = 1; id <= 10; id++)
+        {
+            Assert.AreEqual(CardRarity.Pepemon, PackLoot.RarityOf(id), $"card {id}");
+        }
+    }
+
+    [Test]
+    public void RarityMatchesTheContractPools()
+    {
+        Assert.AreEqual(CardRarity.Common, PackLoot.RarityOf(11));
+        Assert.AreEqual(CardRarity.Common, PackLoot.RarityOf(29));
+        Assert.AreEqual(CardRarity.Rare, PackLoot.RarityOf(18));
+        Assert.AreEqual(CardRarity.Rare, PackLoot.RarityOf(48));
+        Assert.AreEqual(CardRarity.Epic, PackLoot.RarityOf(23));
+        Assert.AreEqual(CardRarity.Epic, PackLoot.RarityOf(49));
+    }
+
+    [Test]
+    public void UnknownCardsFallBackToCommonRatherThanThrowing()
+    {
+        // A card added to the factory later must never stop a pack being revealed.
+        Assert.AreEqual(CardRarity.Common, PackLoot.RarityOf(500));
+    }
+
+    #endregion
+
+    #region gained
+
+    [Test]
+    public void GainedReturnsCardsWhoseBalanceWentUp()
+    {
+        var before = new Dictionary<ulong, int> { { 5, 1 } };
+        var after = new Dictionary<ulong, int> { { 5, 1 }, { 12, 1 }, { 23, 1 } };
+
+        CollectionAssert.AreEqual(new List<ulong> { 12, 23 }, PackLoot.Gained(before, after));
+    }
+
+    [Test]
+    public void GainedReportsOneEntryPerExtraCopy()
+    {
+        var before = new Dictionary<ulong, int> { { 12, 1 } };
+        var after = new Dictionary<ulong, int> { { 12, 4 } };
+
+        CollectionAssert.AreEqual(new List<ulong> { 12, 12, 12 }, PackLoot.Gained(before, after));
+    }
+
+    [Test]
+    public void GainedIgnoresCardsTheWalletAlreadyHad()
+    {
+        var before = new Dictionary<ulong, int> { { 3, 2 }, { 12, 1 } };
+        var after = new Dictionary<ulong, int> { { 3, 2 }, { 12, 1 } };
+
+        CollectionAssert.IsEmpty(PackLoot.Gained(before, after));
+    }
+
+    [Test]
+    public void GainedTreatsAnEmptyStartingWalletAsAllNew()
+    {
+        // GetOwnedCards omits zero balances, so a fresh wallet's snapshot is empty rather than
+        // full of zeroes. Every card in the pack must still be reported.
+        var after = new Dictionary<ulong, int> { { 1, 1 }, { 12, 1 } };
+
+        CollectionAssert.AreEqual(new List<ulong> { 1, 12 }, PackLoot.Gained(new Dictionary<ulong, int>(), after));
+    }
+
+    [Test]
+    public void GainedSurvivesNullSnapshots()
+    {
+        CollectionAssert.IsEmpty(PackLoot.Gained(null, null));
+        CollectionAssert.AreEqual(new List<ulong> { 7 },
+            PackLoot.Gained(null, new Dictionary<ulong, int> { { 7, 1 } }));
+    }
+
+    [Test]
+    public void GainedIgnoresBalancesThatSomehowWentDown()
+    {
+        // Should not happen, but a negative difference must not produce phantom entries.
+        var before = new Dictionary<ulong, int> { { 12, 3 } };
+        var after = new Dictionary<ulong, int> { { 12, 1 } };
+
+        CollectionAssert.IsEmpty(PackLoot.Gained(before, after));
+    }
+
+    #endregion
+
+    #region summary
+
+    [Test]
+    public void SummaryLeadsWithTheRarestCards()
+    {
+        var cards = new List<ulong> { 11, 12, 18, 23, 1 };
+        Assert.AreEqual("1 EPIC  1 PEPEMON  1 RARE  2 COMMON", PackLoot.Summarise(cards));
+    }
+
+    [Test]
+    public void SummaryOmitsRaritiesThatArePresentZeroTimes()
+    {
+        Assert.AreEqual("2 COMMON", PackLoot.Summarise(new List<ulong> { 11, 12 }));
+    }
+
+    [Test]
+    public void SummaryOfNothingIsEmpty()
+    {
+        Assert.AreEqual(string.Empty, PackLoot.Summarise(new List<ulong>()));
+        Assert.AreEqual(string.Empty, PackLoot.Summarise(null));
+    }
+
+    #endregion
+
+    #region price formatting
+
+    [Test]
+    public void PricesRenderAsPlainDecimalsNotScientificNotation()
+    {
+        // 0.0001 ETH is the cheapest tier. Naive double formatting renders this as 1E-04.
+        Assert.AreEqual("0.0001 ETH", EthDisplay.FormatEth(BigInteger.Parse("100000000000000")));
+        Assert.AreEqual("0.0003 ETH", EthDisplay.FormatEth(BigInteger.Parse("300000000000000")));
+        Assert.AreEqual("0.001 ETH", EthDisplay.FormatEth(BigInteger.Parse("1000000000000000")));
+    }
+
+    [Test]
+    public void WholeAndMixedAmountsRenderCorrectly()
+    {
+        Assert.AreEqual("1 ETH", EthDisplay.FormatEth(BigInteger.Pow(10, 18)));
+        Assert.AreEqual("1.5 ETH", EthDisplay.FormatEth(BigInteger.Parse("1500000000000000000")));
+        Assert.AreEqual("12.25 ETH", EthDisplay.FormatEth(BigInteger.Parse("12250000000000000000")));
+    }
+
+    [Test]
+    public void ZeroReadsAsFreeRatherThanZeroEth()
+    {
+        Assert.AreEqual("FREE", EthDisplay.FormatEth(BigInteger.Zero));
+    }
+
+    [Test]
+    public void AmountsTooSmallToShowDoNotRenderAsABareDecimalPoint()
+    {
+        // One wei rounds below six decimals; it must still read as a number.
+        Assert.AreEqual("0 ETH", EthDisplay.FormatEth(BigInteger.One));
+    }
+
+    [Test]
+    public void LargeBalancesDoNotOverflow()
+    {
+        // A decimal cannot hold this; the formatter uses integer maths precisely so it can.
+        Assert.AreEqual("1000000 ETH", EthDisplay.FormatEth(BigInteger.Pow(10, 24)));
+    }
+
+    #endregion
+
+    #region store links
+
+    [Test]
+    public void WebShopBoosterLinksAreRedirectedInGame()
+    {
+        // These links would otherwise sell the player cards on a different contract from the
+        // one the game reads, so they would pay and receive nothing the game can show.
+        Assert.IsTrue(StoreLinks.IsStoreLink("https://pepemon.world/store/boosterpacks"));
+        Assert.IsTrue(StoreLinks.IsStoreLink("https://pepemon.world/store"));
+        Assert.IsTrue(StoreLinks.IsStoreLink("HTTPS://PEPEMON.WORLD/Store/BoosterPacks"));
+    }
+
+    [Test]
+    public void OtherLinksStillOpenInABrowser()
+    {
+        Assert.IsFalse(StoreLinks.IsStoreLink("https://pepemon.world"));
+        Assert.IsFalse(StoreLinks.IsStoreLink("https://docs.pepemon.world/gaming/gaming"));
+        Assert.IsFalse(StoreLinks.IsStoreLink("https://twitter.com/pepemon"));
+    }
+
+    [Test]
+    public void AnUnrelatedStoreLinkIsNotHijacked()
+    {
+        // Only Pepemon's own shop is intercepted; a link to anyone else's store is left alone.
+        Assert.IsFalse(StoreLinks.IsStoreLink("https://opensea.io/store/boosterpacks"));
+    }
+
+    [Test]
+    public void EmptyLinksAreHarmless()
+    {
+        Assert.IsFalse(StoreLinks.IsStoreLink(null));
+        Assert.IsFalse(StoreLinks.IsStoreLink(""));
+        Assert.IsFalse(StoreLinks.IsStoreLink("   "));
+    }
+
+    #endregion
+
+    #region catalogue
+
+    [Test]
+    public void EveryCatalogueTierHasCopyAndAUniqueId()
+    {
+        var seen = new HashSet<byte>();
+        foreach (var tier in PackCatalogue.Tiers)
+        {
+            Assert.IsTrue(seen.Add(tier.Id), $"duplicate tier id {tier.Id}");
+            Assert.IsNotEmpty(tier.Name, $"tier {tier.Id} has no name");
+            Assert.IsNotEmpty(tier.Tagline, $"tier {tier.Id} has no tagline");
+            Assert.IsNotEmpty(tier.Contents, $"tier {tier.Id} has no contents");
+        }
+    }
+
+    [Test]
+    public void CatalogueIdsMatchTheTiersConfiguredOnChain()
+    {
+        // The deploy script configures tiers 1, 2 and 3. A tier in the catalogue with no
+        // matching on-chain tier would silently never appear in the store.
+        CollectionAssert.AreEquivalent(new byte[] { 1, 2, 3 },
+            new List<byte>(System.Linq.Enumerable.Select(PackCatalogue.Tiers, t => t.Id)));
+    }
+
+    #endregion
+}

--- a/Assets/Tests/EditMode/PackLootTests.cs.meta
+++ b/Assets/Tests/EditMode/PackLootTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8792d172506a45d596a965cb49bd7748
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/Pepemon.BattleRules.Tests.asmdef
+++ b/Assets/Tests/EditMode/Pepemon.BattleRules.Tests.asmdef
@@ -4,7 +4,8 @@
     "references": [
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
-        "Pepemon.BattleRules"
+        "Pepemon.BattleRules",
+        "Pepemon.Store"
     ],
     "includePlatforms": [
         "Editor"

--- a/compile-check.sh
+++ b/compile-check.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Compiles Assembly-CSharp with Unity's own Roslyn, without opening the editor and without a
+# licence.
+#
+# Unity's licensing client refuses to issue a token against this editor version, so ./check.sh
+# cannot run here, and CI is a 35-minute round trip. But compiling only needs reference
+# assemblies, and those are all on disk: Unity ships the UnityEngine modules and Roslyn itself,
+# and Library/ScriptAssemblies holds the plugin assemblies from the last successful import.
+#
+# This catches what actually breaks builds - typos, wrong overloads, missing usings, bad
+# namespaces. It does NOT catch scene wiring, and it is not a substitute for CI.
+#
+#   ./compile-check.sh
+set -euo pipefail
+
+UNITY="/Applications/Unity/Hub/Editor/2021.3.12f1/Unity.app/Contents"
+CSC="$UNITY/DotNetSdkRoslyn/csc.dll"
+DOTNET="$UNITY/NetCoreRuntime/dotnet"
+OUT="${TMPDIR:-/tmp}/pepemon-compile-check"
+
+if [ ! -x "$DOTNET" ]; then echo "Unity 2021.3.12f1 not found at $UNITY" >&2; exit 1; fi
+if [ ! -d Library/ScriptAssemblies ]; then
+  echo "Library/ScriptAssemblies is missing - it comes from a previous editor import." >&2
+  echo "Without it the plugin references cannot be resolved. Run a Unity import first." >&2
+  exit 1
+fi
+
+mkdir -p "$OUT"
+rm -f "$OUT"/refs.rsp "$OUT"/sources.rsp
+
+# --- references -------------------------------------------------------------------------
+{
+  # ProjectSettings has apiCompatibilityLevel: 6, i.e. the full .NET Framework profile rather
+  # than netstandard, so the Mono BCL is what the editor actually compiles against. Using the
+  # netstandard reference set instead makes legacy plugins fail with mscorlib 2.0 errors.
+  for d in "$UNITY"/MonoBleedingEdge/lib/mono/unityjit-macos/*.dll; do echo "-r:$d"; done
+  # Facades map netstandard type-forwards onto the Mono BCL. Nethereum and UniTask are built
+  # against netstandard, so without these every async method fails with CS1983.
+  for d in "$UNITY"/MonoBleedingEdge/lib/mono/unityjit-macos/Facades/*.dll; do echo "-r:$d"; done
+  for d in "$UNITY"/Managed/UnityEngine/*.dll; do echo "-r:$d"; done
+  # Plugin and package assemblies, minus the ones this compile produces.
+  for d in Library/ScriptAssemblies/*.dll; do
+    case "$(basename "$d")" in
+      Assembly-CSharp.dll|Assembly-CSharp-Editor.dll|Pepemon.BattleRules.Tests.dll|Tests.dll) ;;
+      *) echo "-r:$d" ;;
+    esac
+  done
+  # Native libraries carry no managed metadata and make Roslyn error out, so skip them.
+  find Assets -name "*.dll" -not -path "*/Editor/*" \
+    | grep -Eiv "/(x86|x64|Windows|Android|iOS|Linux|ARM[0-9]*)/" | sed 's/^/-r:/'
+} | sort -u > "$OUT/refs.rsp"
+
+# --- sources ----------------------------------------------------------------------------
+# Assembly-CSharp is everything under Assets that is not inside an assembly definition and not
+# in an Editor folder.
+find Assets -name "*.cs" \
+  -not -path "Assets/Thirdweb/*" \
+  -not -path "Assets/Plugins/*" \
+  -not -path "Assets/UnitySQLiteAsync/*" \
+  -not -path "Assets/Tests/*" \
+  -not -path "Assets/Scripts/BattleRules/*" \
+  -not -path "Assets/Scripts/Store/*" \
+  -not -path "*/Editor/*" \
+  | sort > "$OUT/sources.rsp"
+
+echo "==> compiling Pepemon.Store"
+"$DOTNET" "$CSC" -nologo -target:library -langversion:9.0 -nostdlib+ -nowarn:CS0169,CS0414,CS0649 \
+  -out:"$OUT/Pepemon.Store.dll" \
+  $(for d in "$UNITY"/MonoBleedingEdge/lib/mono/unityjit-macos/*.dll; do echo "-r:$d"; done) \
+  $(for d in "$UNITY"/MonoBleedingEdge/lib/mono/unityjit-macos/Facades/*.dll; do echo "-r:$d"; done) \
+  Assets/Scripts/Store/*.cs
+
+echo "==> compiling Assembly-CSharp ($(wc -l < "$OUT/sources.rsp" | tr -d ' ') files)"
+"$DOTNET" "$CSC" -nologo -target:library -langversion:9.0 -unsafe -nostdlib+ \
+  -nowarn:CS0169,CS0414,CS0649,CS0618,CS0672,CS0114,CS0108,CS1998,CS4014,CS0162 \
+  -define:UNITY_2021_3_OR_NEWER -define:UNITY_2021_3 -define:UNITY_2021 -define:UNITY_5_3_OR_NEWER \
+  -define:UNITY_EDITOR -define:UNITY_STANDALONE_OSX -define:ODIN_INSPECTOR -define:ODIN_INSPECTOR_3 \
+  -out:"$OUT/Assembly-CSharp.dll" \
+  "-r:$OUT/Pepemon.Store.dll" \
+  "@$OUT/refs.rsp" "@$OUT/sources.rsp"
+
+NUNIT=$(find Library/PackageCache -name "nunit.framework.dll" 2>/dev/null | head -1)
+TESTRUNNER=$(ls Library/ScriptAssemblies/UnityEngine.TestRunner.dll 2>/dev/null || true)
+
+if [ -n "$NUNIT" ]; then
+  echo "==> compiling EditMode tests"
+  "$DOTNET" "$CSC" -nologo -target:library -langversion:9.0 -nostdlib+ \
+    -nowarn:CS0169,CS0414,CS0649 \
+    -out:"$OUT/Pepemon.BattleRules.Tests.dll" \
+    $(for d in "$UNITY"/MonoBleedingEdge/lib/mono/unityjit-macos/*.dll; do echo "-r:$d"; done) \
+    $(for d in "$UNITY"/MonoBleedingEdge/lib/mono/unityjit-macos/Facades/*.dll; do echo "-r:$d"; done) \
+    $(for d in "$UNITY"/Managed/UnityEngine/*.dll; do echo "-r:$d"; done) \
+    ${TESTRUNNER:+-r:$TESTRUNNER} \
+    "-r:$NUNIT" \
+    "-r:$OUT/Pepemon.Store.dll" \
+    -r:Library/ScriptAssemblies/Pepemon.BattleRules.dll \
+    Assets/Tests/EditMode/*.cs
+else
+  echo "==> skipping EditMode tests (nunit.framework.dll not found in Library/PackageCache)"
+fi
+
+echo
+echo "==> COMPILE OK"


### PR DESCRIPTION
Adds a booster pack store inside the game. Packs mint onto the same `PepemonFactory` the game already reads, so what a player buys appears in the deck editor with no extra step.

**Needs [pepemon-dao/battle-contracts#42](https://github.com/pepemon-dao/battle-contracts/pull/42) deployed first**, with its address set in `Web3Settings.pepemonBoosterPackAddress`. Until then `IsConfigured` is false and the store shows *"not live on this network yet"* instead of throwing — so this is safe to merge and build before the contract exists.

## No scene changes at all

Every hard bug in this project so far has been a serialized reference left unassigned or a checkbox set the wrong way — invisible when reading C#, each costing a full build to find. So:

- The screen is **built at runtime** like `PixelNotice`. No prefab, no scene object, nothing to leave unwired.
- The two existing Store buttons already point at `pepemon.world/store/boosterpacks`, so `OpenLinkButton` intercepts that URL rather than the scene being rewired. I verified both URLs in `StartScreen.unity`; the third button (`pepemon.world`) still opens a browser.
- The ABI is a `const` in `PepemonBoosterPack`, not a `Web3Settings` field — it belongs to the contract source, not a deployment, and hand-pasting a JSON blob into scene YAML is exactly the invisible mistake worth avoiding.

## A correctness fix, not just convenience

The web shop's booster packs mint onto **`0xae0b8933…`**, a different cards contract from the one this game reads (**`0x888c8302…`**). A player who followed those Store links would have paid for cards the game can never show them. Intercepting the link is the difference between a sale and a support ticket.

## The free faucet is hidden

`mintCards()` hands out one of every card in the game for free, so leaving that button beside a paid store would make the store pointless. The listener stays wired and the function still works — it is permissionless and cannot be disabled without the deployer key, so hiding the button is the honest description of what this does.

## Getting the money right

- **Price and pack size are always read from chain**, never assumed. The contract rejects underpayment *and* overpayment, so a stale client-side price would make every purchase revert. Only names and rarity blurbs are local.
- **Purchases send an explicit gas limit.** Pack gas is data-dependent and the seed moves between the wallet's estimate and execution, so a bare estimate is sometimes short — without headroom, purchases fail intermittently and the player pays for nothing.
- Rejected-in-wallet and reverted are separate, first-class states. Neither leaves the buy button dead.
- If the transaction succeeds but no new balance appears, it says so and points at the Deck screen rather than claiming a reward it cannot see.

The reveal diffs card balances around the purchase rather than decoding the `PackOpened` event: balance reads are already used all over the game, whereas log decoding differs between the WebGL bridge and native and would need a code path for each.

## New: a local compile gate

`compile-check.sh` compiles `Assembly-CSharp` with Unity's own Roslyn — **no editor, no licence**. The licensing client refuses to issue a token against this editor version, so `./check.sh` cannot run locally and CI is a 35-minute round trip.

```
./compile-check.sh
```

It already paid for itself: it caught that the store logic, originally `PackRewards`, is **ambiguous against `Thirdweb.PackRewards`** and fails to compile. That would otherwise have been a 35-minute CI failure. Renamed to `PackLoot`.

It covers typos, wrong overloads, missing usings and bad namespaces. It does **not** cover scene wiring and does not replace CI.

## Tests

`PackLootTests` covers what is checkable without a chain or scene: rarity mapping, the balance diff (empty wallets, duplicate cards, balances that go down), the reveal summary, wei formatting, and which links are intercepted.

Wei formatting uses integer maths rather than decimal — `0.0001 ETH` renders as `1E-04` under naive formatting, and a `decimal` cannot hold large wei balances. All assertions were also executed locally through a standalone harness, not just compiled.

## Not done

- Nothing is deployed. The contract PR must land and be deployed first.
- Pack art in the reveal falls back to card ids when `PepemonFactoryCardCache` has not preloaded images.
- PPDEX pricing, and ChainLink VRF for randomness, remain backlogged.
