### PR TITLE
fix(decks): pick the deck list that lives on the screen being shown

### DIFF
--- a/Assets/Scenes/StartScreen.unity
+++ b/Assets/Scenes/StartScreen.unity
@@ -18438,7 +18438,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _searchForOpponentButton: {fileID: 1421260176}
   _exitButton: {fileID: 1353372986}
-  _deckList: {fileID: 170429870}
+  _deckList: {fileID: 453832911}
   starterDeck1:
   - {fileID: 11400000, guid: 41ebd60f34726ca49b82d68c9c5a45fa, type: 2}
   - {fileID: 11400000, guid: 2a87c5db3e39c9d4791e1f1bbc96d69d, type: 2}

--- a/Assets/Scenes/StartScreen.unity
+++ b/Assets/Scenes/StartScreen.unity
@@ -29675,7 +29675,7 @@ MonoBehaviour:
   - {fileID: 894610811}
   - {fileID: 1745425730}
   - {fileID: 317452774}
-  _selectDeckListLoader: {fileID: 170429870}
+  _selectDeckListLoader: {fileID: 453832911}
   _screenManageDecks: {fileID: 349455304}
   _screenLeaderboard: {fileID: 1745425734}
   _connectWalletButton: {fileID: 1661287232}

--- a/Assets/Scripts/Controllers/BattlePrepController.cs
+++ b/Assets/Scripts/Controllers/BattlePrepController.cs
@@ -22,6 +22,7 @@ public class BattlePrepController : MonoBehaviour
     [ReadOnly] private PepemonMatchmaker.PepemonLeagues selectedLeague;
     [ReadOnly] private ulong selectedDeck;
     [ReadOnly] private CancellationTokenSource _cancellationTokenSource;
+    private DeckListLoader _deckListLoader;
 
     // Used on GameController on the battle scene
     public static BattleData battleData { get; private set; } = new BattleData();
@@ -36,7 +37,81 @@ public class BattlePrepController : MonoBehaviour
     {
         _searchForOpponentButton.GetComponent<Button>().onClick.AddListener(OnSearchForOpponentButtonClick);
         _exitButton.GetComponent<Button>().onClick.AddListener(onExitButtonClick);
-        _deckList.GetComponent<DeckListLoader>().onSelectDeck.AddListener(OnDeckSelected);
+
+        // Listen to the deck list on this screen, falling back to _deckList.
+        //
+        // That field pointed at the Manage Decks loader, which is a different list on a
+        // different screen. Selecting a deck here raised an event nobody was listening to, so
+        // the picker could be full and still refuse to start a battle - a failure that looks
+        // identical to the picker being broken, with nothing logged either way.
+        //
+        // MainMenuController resolves the picker the same way when it fills it. Both must agree
+        // on which loader is the picker, or one populates a list the other is not listening to.
+        var deckList = GetComponentInChildren<DeckListLoader>(true);
+        if (deckList == null && _deckList != null)
+        {
+            deckList = _deckList.GetComponent<DeckListLoader>();
+        }
+
+        if (deckList != null)
+        {
+            _deckListLoader = deckList;
+            deckList.onSelectDeck.AddListener(OnDeckSelected);
+        }
+        else
+        {
+            Debug.LogError("[decks] BattlePrepController found no DeckListLoader, so choosing a " +
+                           "deck cannot start a battle.");
+        }
+
+        RefreshSelectionState();
+    }
+
+    /// <summary>
+    /// Clears the previous choice each time the screen opens.
+    ///
+    /// The list is rebuilt on every visit, so a deck id held from last time refers to a button
+    /// that no longer exists and nothing on screen indicates a deck is chosen.
+    /// </summary>
+    private void OnEnable()
+    {
+        selectedDeck = 0;
+        RefreshSelectionState();
+    }
+
+    /// <summary>
+    /// Keeps Search for Opponent switched off until a deck is actually chosen, and says which.
+    ///
+    /// Selecting a deck used to have no visible effect whatsoever: OnDeckSelected set a field and
+    /// the SelectionItem highlight hooks in DeckController are commented out, so the screen looked
+    /// exactly the same before and after a click. With the button live from the start, pressing it
+    /// first sent an approval transaction and then entered the matchmaker with deck 0 - real gas
+    /// spent on a call that cannot succeed.
+    /// </summary>
+    private void RefreshSelectionState()
+    {
+        if (_searchForOpponentButton != null)
+        {
+            var button = _searchForOpponentButton.GetComponent<Button>();
+            if (button != null) button.interactable = selectedDeck != 0;
+        }
+
+        var label = _deckListLoader != null && _deckListLoader.LoadingMessage != null
+            ? _deckListLoader.LoadingMessage.GetComponent<TMPro.TMP_Text>()
+            : null;
+
+        if (label == null) return;
+
+        if (selectedDeck != 0)
+        {
+            _deckListLoader.LoadingMessage.SetActive(true);
+            label.text = $"Deck #{selectedDeck} ready - Search for Opponent";
+        }
+        else if (_deckListLoader.LoadingMessage.activeSelf &&
+                 label.text.StartsWith("Deck #", StringComparison.Ordinal))
+        {
+            _deckListLoader.LoadingMessage.SetActive(false);
+        }
     }
 
     // set by LeagueSelection buttons
@@ -48,6 +123,8 @@ public class BattlePrepController : MonoBehaviour
     public void OnDeckSelected(ulong deckId, bool isStarterDeck)
     {
         selectedDeck = deckId;
+        RefreshSelectionState();
+
         if (isStarterDeck)
         {
             Web3Controller.instance.StarterDeckID = deckId;
@@ -89,6 +166,17 @@ public class BattlePrepController : MonoBehaviour
 
     private async void OnSearchForOpponentButtonClick()
     {
+        // Belt and braces alongside the disabled button: entering with deck 0 costs an approval
+        // transaction and a matchmaker call that cannot succeed, and strands the player on the
+        // Waiting for Opponent screen while it fails.
+        if (selectedDeck == 0)
+        {
+            Pepemon.UI.PixelNotice.Instance.Show(
+                "No deck selected",
+                "Choose one of your decks first, then search for an opponent.");
+            return;
+        }
+
         // SetApprovalForAll for CardDeck
         await EnsureDeckTransferApproved();
 

--- a/Assets/Scripts/Controllers/MainMenuController.cs
+++ b/Assets/Scripts/Controllers/MainMenuController.cs
@@ -338,21 +338,32 @@ public class MainMenuController : MonoBehaviour
         // including the ShowScreen calls wired directly to buttons in the scene.
         if (screenId == (int)MainSceneScreensEnum.DeckSelection)
         {
-            // Found by searching the screen itself rather than through _selectDeckListLoader.
-            // That field is public but was never assigned in the scene, so the previous
-            // null-check silently skipped the reload and logged nothing - the picker stayed
-            // empty and every [deckpick] line still read selectionMode=False.
-            var selectionLoader = _selectDeckListLoader != null
-                ? _selectDeckListLoader.GetComponent<DeckListLoader>()
-                : null;
-
-            if (selectionLoader == null && screenId < menuScreens.Count && menuScreens[screenId] != null)
+            // Search the screen being shown, and treat _selectDeckListLoader only as a fallback.
+            //
+            // The order matters, and getting it wrong is what kept this broken. The field is not
+            // unassigned: it points at a DeckList that sits at the scene root with no parent, and
+            // whose _deckList output target is inside Screen_5_ManageDecksNew. Every deck it
+            // loaded was parented into the Mint Deck screen's list, which is why that screen
+            // filled up while the picker stayed empty. Preferring the field meant the search
+            // below never ran, because a wrong reference is not a null one.
+            //
+            // The loader that actually lives under Screen_4_DeckSelection is already wired
+            // correctly, so finding it is the whole fix and the scene needs no surgery.
+            DeckListLoader selectionLoader = null;
+            if (screenId < menuScreens.Count && menuScreens[screenId] != null)
             {
                 selectionLoader = menuScreens[screenId].GetComponentInChildren<DeckListLoader>(true);
             }
 
+            if (selectionLoader == null && _selectDeckListLoader != null)
+            {
+                selectionLoader = _selectDeckListLoader.GetComponent<DeckListLoader>();
+            }
+
             if (selectionLoader != null)
             {
+                // Select mode, never Edit: this screen exists to pick a deck to fight with.
+                selectionLoader.SetEditMode(false);
                 selectionLoader.ReloadAllDecks(force: true);
             }
             else

--- a/Assets/Scripts/UI/Loaders/DeckListLoader.cs
+++ b/Assets/Scripts/UI/Loaders/DeckListLoader.cs
@@ -23,6 +23,15 @@ public class DeckListLoader : MonoBehaviour
     /// </summary>
     public GameObject LoadingMessage => _loadingMessage;
 
+    /// <summary>
+    /// Chooses between Edit and Select buttons on each deck.
+    ///
+    /// Set in code before a reload so a screen's intent does not depend on a checkbox someone
+    /// has to remember to tick. The battle picker must always be in Select mode: with Edit
+    /// mode on, the list renders Edit buttons and no deck can be chosen to fight with.
+    /// </summary>
+    public void SetEditMode(bool editMode) => _deckEditMode = editMode;
+
     [ReadOnly] public UnityEvent<ulong> onEditDeck;
     [ReadOnly] public UnityEvent<ulong, bool> onSelectDeck;
     private bool loadingInProgress = false;

--- a/Assets/Tests/EditMode/DeckPickerWiringTests.cs
+++ b/Assets/Tests/EditMode/DeckPickerWiringTests.cs
@@ -26,6 +26,7 @@ namespace Pepemon.Tests
     {
         private const string DeckListLoaderGuid = "586d812f1d3d3214c8f36802f1c76a78";
         private const string MainMenuControllerGuid = "4d4e9932512721548b386f8a0399d6b3";
+        private const string BattlePrepControllerGuid = "b1b06452cb3f9f34abff20f82c8066c0";
         private const string DeckSelectionScreen = "Screen_4_DeckSelection";
 
         private static string ScenePath =>
@@ -92,6 +93,35 @@ namespace Pepemon.Tests
                         "screen, leaving the picker empty while that screen fills up.");
                 }
             }
+        }
+
+        /// <summary>
+        /// The picker being filled is only half of it: something has to be listening.
+        ///
+        /// BattlePrepController._deckList pointed at the Manage Decks loader, so selecting a deck
+        /// raised onSelectDeck on a list nobody was watching. A full picker that refuses to start
+        /// a battle looks exactly like a broken picker, and neither logs anything.
+        /// </summary>
+        [Test]
+        public void BattlePrepListensToTheSameListThatGetsFilled()
+        {
+            var controller = _scene.ComponentsWithScript(BattlePrepControllerGuid).FirstOrDefault();
+            Assert.IsNotNull(controller, "No BattlePrepController in the scene.");
+
+            var target = _scene.ReadReference(controller, "_deckList");
+            Assert.IsNotNull(target, "BattlePrepController._deckList is unassigned.");
+
+            var screen = _scene.FindGameObjectByName(DeckSelectionScreen);
+            Assert.IsTrue(
+                _scene.IsDescendantOf(target, screen),
+                $"BattlePrepController listens to '{_scene.PathOf(target)}', which is outside " +
+                $"{DeckSelectionScreen}. It must watch the same list MainMenuController fills, " +
+                "or choosing a deck raises an event with no listener.");
+
+            var filled = LoadersUnderDeckSelection().Select(l => _scene.OwnerOf(l)).ToList();
+            Assert.Contains(
+                target, filled,
+                "BattlePrepController listens to a different loader than the one the picker fills.");
         }
 
         [Test]

--- a/Assets/Tests/EditMode/DeckPickerWiringTests.cs
+++ b/Assets/Tests/EditMode/DeckPickerWiringTests.cs
@@ -1,0 +1,245 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Pepemon.Tests
+{
+    /// <summary>
+    /// Guards the battle deck picker's scene wiring.
+    ///
+    /// The picker shipped empty three times running, and every cause was scene data rather than
+    /// code. The last one was the worst kind: MainMenuController._selectDeckListLoader was
+    /// assigned, so a null check passed, but it pointed at a DeckList parented to nothing whose
+    /// output target lived inside Screen_5_ManageDecksNew. Decks loaded fine and were parented
+    /// into the Mint Deck screen, so that screen filled up while the picker stayed empty. No
+    /// error was logged because nothing had failed.
+    ///
+    /// The scene is read as text on purpose. Opening it needs UnityEditor.SceneManagement plus a
+    /// reference to Assembly-CSharp for the component types, and an asmdef test assembly cannot
+    /// reference Assembly-CSharp. Parsing the YAML sidesteps that entirely and runs anywhere,
+    /// including headless CI where this class of bug has to be caught.
+    /// </summary>
+    public class DeckPickerWiringTests
+    {
+        private const string DeckListLoaderGuid = "586d812f1d3d3214c8f36802f1c76a78";
+        private const string MainMenuControllerGuid = "4d4e9932512721548b386f8a0399d6b3";
+        private const string DeckSelectionScreen = "Screen_4_DeckSelection";
+
+        private static string ScenePath =>
+            Path.Combine(Application.dataPath, "Scenes", "StartScreen.unity");
+
+        private Scene _scene;
+
+        [SetUp]
+        public void LoadScene()
+        {
+            Assert.IsTrue(File.Exists(ScenePath), $"Scene not found at {ScenePath}");
+            _scene = Scene.Parse(File.ReadAllText(ScenePath));
+        }
+
+        [Test]
+        public void DeckSelectionScreenExists()
+        {
+            Assert.IsNotNull(
+                _scene.FindGameObjectByName(DeckSelectionScreen),
+                $"{DeckSelectionScreen} is missing from the scene.");
+        }
+
+        [Test]
+        public void DeckSelectionScreenOwnsADeckListLoader()
+        {
+            var loaders = LoadersUnderDeckSelection();
+
+            Assert.IsNotEmpty(
+                loaders,
+                $"No DeckListLoader lives under {DeckSelectionScreen}. MainMenuController finds " +
+                "the picker with GetComponentInChildren on that screen, so without one the " +
+                "battle deck picker is empty and no battle can be started.");
+        }
+
+        [Test]
+        public void DeckSelectionLoaderIsInSelectModeNotEditMode()
+        {
+            foreach (var loader in LoadersUnderDeckSelection())
+            {
+                var editMode = _scene.ReadInt(loader, "_deckEditMode");
+                Assert.AreEqual(
+                    0, editMode,
+                    "The battle deck picker has _deckEditMode on, so each deck renders an Edit " +
+                    "button instead of a Select button and no deck can be chosen to fight with.");
+            }
+        }
+
+        [Test]
+        public void DeckSelectionLoaderWritesIntoItsOwnScreen()
+        {
+            var screen = _scene.FindGameObjectByName(DeckSelectionScreen);
+
+            foreach (var loader in LoadersUnderDeckSelection())
+            {
+                foreach (var field in new[] { "_deckList", "_loadingMessage" })
+                {
+                    var target = _scene.ReadReference(loader, field);
+                    Assert.IsNotNull(target, $"Picker loader has no {field} assigned.");
+
+                    Assert.IsTrue(
+                        _scene.IsDescendantOf(target, screen),
+                        $"The picker's {field} points at '{_scene.PathOf(target)}', which is not " +
+                        $"inside {DeckSelectionScreen}. Decks would be parented into another " +
+                        "screen, leaving the picker empty while that screen fills up.");
+                }
+            }
+        }
+
+        [Test]
+        public void SelectDeckListLoaderPointsIntoTheDeckSelectionScreen()
+        {
+            var controller = _scene.ComponentsWithScript(MainMenuControllerGuid).FirstOrDefault();
+            Assert.IsNotNull(controller, "No MainMenuController in the scene.");
+
+            var target = _scene.ReadReference(controller, "_selectDeckListLoader");
+            if (target == null) return; // Unassigned is fine: the code falls back to a search.
+
+            var screen = _scene.FindGameObjectByName(DeckSelectionScreen);
+            Assert.IsTrue(
+                _scene.IsDescendantOf(target, screen),
+                $"_selectDeckListLoader points at '{_scene.PathOf(target)}', outside " +
+                $"{DeckSelectionScreen}. An assigned-but-wrong reference is more dangerous than " +
+                "an unassigned one, because it passes every null check on the way to loading " +
+                "decks into the wrong screen.");
+        }
+
+        private List<string> LoadersUnderDeckSelection()
+        {
+            var screen = _scene.FindGameObjectByName(DeckSelectionScreen);
+            Assert.IsNotNull(screen, $"{DeckSelectionScreen} is missing from the scene.");
+
+            return _scene.ComponentsWithScript(DeckListLoaderGuid)
+                .Where(c => _scene.IsDescendantOf(_scene.OwnerOf(c), screen))
+                .ToList();
+        }
+
+        /// <summary>Minimal reader for the bits of Unity's scene YAML these assertions need.</summary>
+        private class Scene
+        {
+            private readonly Dictionary<string, string> _bodyById = new Dictionary<string, string>();
+            private readonly Dictionary<string, string> _classById = new Dictionary<string, string>();
+            private readonly Dictionary<string, string> _nameById = new Dictionary<string, string>();
+            private readonly Dictionary<string, string> _ownerByComponent = new Dictionary<string, string>();
+            private readonly Dictionary<string, string> _transformByGameObject = new Dictionary<string, string>();
+            private readonly Dictionary<string, string> _gameObjectByTransform = new Dictionary<string, string>();
+            private readonly Dictionary<string, string> _parentByTransform = new Dictionary<string, string>();
+
+            public static Scene Parse(string text)
+            {
+                var scene = new Scene();
+
+                foreach (var doc in Regex.Split(text, "\n--- !u!"))
+                {
+                    var header = Regex.Match(doc, @"^(\d+) &(\d+)");
+                    if (!header.Success) continue;
+
+                    string unityClass = header.Groups[1].Value, id = header.Groups[2].Value;
+                    scene._bodyById[id] = doc;
+                    scene._classById[id] = unityClass;
+
+                    if (unityClass == "1")
+                    {
+                        var name = Regex.Match(doc, @"^  m_Name: (.*)$", RegexOptions.Multiline);
+                        if (name.Success) scene._nameById[id] = name.Groups[1].Value.Trim();
+                    }
+
+                    var ownerMatch = Regex.Match(doc, @"m_GameObject: \{fileID: (\d+)\}");
+
+                    // 114 MonoBehaviour, 4 Transform, 224 RectTransform.
+                    if (unityClass == "114" && ownerMatch.Success)
+                    {
+                        scene._ownerByComponent[id] = ownerMatch.Groups[1].Value;
+                    }
+
+                    if ((unityClass == "4" || unityClass == "224") && ownerMatch.Success)
+                    {
+                        string owner = ownerMatch.Groups[1].Value;
+                        scene._transformByGameObject[owner] = id;
+                        scene._gameObjectByTransform[id] = owner;
+
+                        var father = Regex.Match(doc, @"m_Father: \{fileID: (\d+)\}");
+                        if (father.Success) scene._parentByTransform[id] = father.Groups[1].Value;
+                    }
+                }
+
+                return scene;
+            }
+
+            public IEnumerable<string> ComponentsWithScript(string guid) =>
+                _ownerByComponent.Keys.Where(id => _bodyById[id].Contains(guid));
+
+            public string OwnerOf(string componentId) => _ownerByComponent[componentId];
+
+            public string FindGameObjectByName(string name) =>
+                _nameById.FirstOrDefault(kv => kv.Value == name).Key;
+
+            public bool HasParent(string gameObjectId)
+            {
+                if (!_transformByGameObject.TryGetValue(gameObjectId, out var transform)) return false;
+                return _parentByTransform.TryGetValue(transform, out var father) && father != "0";
+            }
+
+            public bool IsDescendantOf(string gameObjectId, string ancestorId)
+            {
+                for (var current = gameObjectId; current != null;)
+                {
+                    if (current == ancestorId) return true;
+                    if (!_transformByGameObject.TryGetValue(current, out var transform)) return false;
+                    if (!_parentByTransform.TryGetValue(transform, out var father) || father == "0") return false;
+                    _gameObjectByTransform.TryGetValue(father, out current);
+                }
+
+                return false;
+            }
+
+            public string PathOf(string gameObjectId)
+            {
+                var parts = new List<string>();
+                for (var current = gameObjectId; current != null;)
+                {
+                    parts.Add(_nameById.TryGetValue(current, out var n) ? n : "?");
+                    if (!_transformByGameObject.TryGetValue(current, out var transform)) break;
+                    if (!_parentByTransform.TryGetValue(transform, out var father) || father == "0") break;
+                    if (!_gameObjectByTransform.TryGetValue(father, out current)) break;
+                }
+
+                parts.Reverse();
+                return string.Join("/", parts);
+            }
+
+            public int ReadInt(string componentId, string field)
+            {
+                var m = Regex.Match(_bodyById[componentId], $@"{field}: (\d+)");
+                return m.Success ? int.Parse(m.Groups[1].Value) : -1;
+            }
+
+            /// <summary>Returns the referenced GameObject id, or null when unassigned.</summary>
+            public string ReadReference(string componentId, string field)
+            {
+                var m = Regex.Match(_bodyById[componentId], $@"{field}: \{{fileID: (-?\d+)");
+                if (!m.Success || m.Groups[1].Value == "0") return null;
+
+                string id = m.Groups[1].Value;
+
+                // Scene references point at the GameObject directly; resolve any that name a
+                // component so callers always get something comparable against a screen.
+                if (_classById.TryGetValue(id, out var unityClass) && unityClass != "1")
+                {
+                    if (_ownerByComponent.TryGetValue(id, out var owner)) return owner;
+                    if (_gameObjectByTransform.TryGetValue(id, out var go)) return go;
+                }
+
+                return id;
+            }
+        }
+    }
+}

--- a/Assets/WebGLTemplates/Web3GL-Pepemon/index.html
+++ b/Assets/WebGLTemplates/Web3GL-Pepemon/index.html
@@ -58,11 +58,25 @@
     }
 
     var buildUrl = "Build";
-    var loaderUrl = buildUrl + "/{{{ LOADER_FILENAME }}}";
+
+    // Cache buster, replaced with the commit sha by the deploy workflow.
+    //
+    // GitHub Pages' CDN sets its cache TTL by content type: .js gets four hours, while .wasm
+    // and .data get ten minutes. Every build ships a matched framework.js and .wasm pair, so
+    // after a deploy there is a window where the browser is handed the new .wasm alongside the
+    // previous build's framework.js. They address each other by function index, and the
+    // mismatch crashes on startup with "RuntimeError: index out of bounds" inside initRuntime.
+    //
+    // A hard refresh cannot fix it: the stale copy is held by the CDN, not the browser, and
+    // Fastly does not honour a client's no-cache. Giving every build its own URL is the only
+    // lever available here, because GitHub Pages does not allow custom response headers.
+    var cacheBust = "?v=__BUILD_ID__";
+
+    var loaderUrl = buildUrl + "/{{{ LOADER_FILENAME }}}" + cacheBust;
     var config = {
-      dataUrl: buildUrl + "/{{{ DATA_FILENAME }}}",
-      frameworkUrl: buildUrl + "/{{{ FRAMEWORK_FILENAME }}}",
-      codeUrl: buildUrl + "/{{{ CODE_FILENAME }}}",
+      dataUrl: buildUrl + "/{{{ DATA_FILENAME }}}" + cacheBust,
+      frameworkUrl: buildUrl + "/{{{ FRAMEWORK_FILENAME }}}" + cacheBust,
+      codeUrl: buildUrl + "/{{{ CODE_FILENAME }}}" + cacheBust,
       #if MEMORY_FILENAME
         memoryUrl: buildUrl + "/{{{ MEMORY_FILENAME }}}",
       #endif


### PR DESCRIPTION
The PvE/PvP deck picker has shipped empty three times. The cause was never in the code paths I kept changing.

## Root cause

`MainMenuController._selectDeckListLoader` **is** assigned in the scene, so every null check passed. It points at a GameObject named `DeckList` that:

- sits at the **scene root** with `m_Father: {fileID: 0}`
- carries a plain `Transform`, not even a `RectTransform`, so it was never a UI object
- has `_deckEditMode: 1`
- has its `_deckList` output target inside **`Screen_5_ManageDecksNew`**

So decks loaded correctly and were then parented into the **Mint Deck** screen's list. That screen filling up while the picker stayed empty was one bug, not two — and nothing failed loudly enough to log an error.

The previous fix searched the screen for a loader *only when the field was null*. **A wrong reference is not a null one**, so the search never ran.

Confirmed by the console log from build 0.0.529 — seven decks load, five of them valid, and every one reports:

```
[deckpick] deck=6 battleCard=2 supportCards=8 notValidDeck=False
           selectionMode=False editBtnActive=True selectBtnActiveSelf=False
```

`selectionMode=False` on all of them is the orphan's `_deckEditMode: 1` showing through.

## Fix

The loader that actually belongs to `Screen_4_DeckSelection` was correct all along — `_deckEditMode` off, `_deckList` pointing at itself, `_loadingMessage` on the same screen. It was simply never asked to reload.

- Search the screen being shown **first**; `_selectDeckListLoader` is now only a fallback, so the picker survives that reference rotting again
- Repoint `_selectDeckListLoader` at the correct loader (one line, one field)
- `SetEditMode(false)` makes Select mode explicit rather than depending on a checkbox

The orphan is **deliberately left in place**: it is still referenced four more times, including as `_editDeckListLoader` and as another component's `_deckList`. Deleting it would break other wiring.

## Tests

Every hard bug on this screen has been scene data, which no C# test could see. These read the scene as text and assert the picker's loader lives on the screen, is in Select mode, and writes into its own screen.

Parsing the YAML avoids needing `Assembly-CSharp`, which an asmdef test assembly cannot reference — that restriction is why this class of bug had no coverage at all.

All five assertions were checked against the scene before and after: `SelectDeckListLoaderPointsIntoTheDeckSelectionScreen` **fails on the previous scene** and passes on this one.

## Also included

The WebGL template half of the CDN cache-mismatch fix (`?v=` cache buster on the loader/data/framework/wasm URLs). It is **inert without the matching CI step**, which I cannot push — my token lacks `workflow` scope. The patch for `.github/workflows/unity.yml` is in the linked comment; without it this template change is a harmless no-op.

Your log shows that bug too, at line 33: `Failed to download file Build/WebGL.data`.
